### PR TITLE
Resizable focus modal width

### DIFF
--- a/src/multi-panel/App.tsx
+++ b/src/multi-panel/App.tsx
@@ -39,6 +39,7 @@ import {
 import { runtimeAsset } from "@/multi-panel/lib/runtime";
 import { DEFAULT_LAYOUT } from "@/shared/lib/layouts";
 import { DEFAULT_PANEL_PROVIDERS } from "@/shared/lib/constants";
+import { DEFAULT_FOCUS_MODAL_WIDTH } from "@/shared/lib/settings";
 import { getProviderById, type ProviderId } from "@/shared/lib/providers";
 import type {
   SettingsTab,
@@ -351,6 +352,7 @@ export function App() {
     setPanelProviders(nextPanelProviders);
     void updateSettings({
       currentLayout: DEFAULT_LAYOUT,
+      focusModalWidth: DEFAULT_FOCUS_MODAL_WIDTH,
       panelProviders: nextPanelProviders,
     });
     showStatus(t("statusLayoutReset", "Panel layout reset."));
@@ -428,6 +430,7 @@ export function App() {
   return (
     <div className="parallel-ai-app relative h-full overflow-hidden">
       <PanelWorkspace
+        focusModalWidth={settings.focusModalWidth}
         focusedSlotIndex={focusedSlotIndex}
         googleMode={settings.googleProviderMode}
         horizontalPanelGroupRefs={horizontalPanelGroupRefs}
@@ -436,6 +439,7 @@ export function App() {
         mainCanvasRef={mainCanvasRef}
         onBeginPanelDrag={beginPanelDrag}
         onCloseFocus={() => setFocusedSlotIndex(null)}
+        onCommitFocusModalWidth={(width) => void updateSetting("focusModalWidth", width)}
         onFocusPanel={setFocusedSlotIndex}
         onOpenFocusedInTab={handleOpenFocusedInTab}
         onRefreshProvider={refreshProvider}

--- a/src/multi-panel/components/PanelWorkspace.tsx
+++ b/src/multi-panel/components/PanelWorkspace.tsx
@@ -8,12 +8,43 @@ import {
 
 import { EmptyPanelSlot } from "@/multi-panel/components/EmptyPanelSlot";
 import { PanelFrame } from "@/multi-panel/components/PanelFrame";
+import {
+  getFocusEdgeLeft,
+  getFocusModalWidthStyle,
+  useFocusModalResize,
+  type FocusModalEdge,
+} from "@/multi-panel/hooks/useFocusModalResize";
 import { getColumnPanelId, getPanelUrl, getRowPanelId } from "@/multi-panel/lib/panel-layout";
+import { useTranslation } from "@/shared/contexts/I18nContext";
 import { ALL_PROVIDER_IDS, getProviderById, type Provider, type ProviderId } from "@/shared/lib/providers";
 import type { GoogleProviderMode, PanelProviderSlot } from "@/shared/lib/settings";
 import { LAYOUTS, type LayoutId } from "@/shared/lib/layouts";
 
+// Focused-modal geometry. The handles are inset from the modal's top/bottom so
+// they clear its rounded corners (see the resize handles below).
+const FOCUS_MODAL_TOP = "2vh";
+const FOCUS_MODAL_HEIGHT = "96vh";
+const FOCUS_HANDLE_INSET = 24;
+
+const FOCUS_HANDLES: ReadonlyArray<{
+  edge: FocusModalEdge;
+  ariaKey: string;
+  ariaFallback: string;
+}> = [
+  {
+    edge: "left",
+    ariaKey: "focusResizeLeftAria",
+    ariaFallback: "Resize focus view from the left edge",
+  },
+  {
+    edge: "right",
+    ariaKey: "focusResizeRightAria",
+    ariaFallback: "Resize focus view from the right edge",
+  },
+];
+
 interface PanelWorkspaceProps {
+  focusModalWidth: number;
   focusedSlotIndex: number | null;
   googleMode: GoogleProviderMode;
   horizontalPanelGroupRefs: MutableRefObject<Record<number, GroupImperativeHandle | null>>;
@@ -29,6 +60,7 @@ interface PanelWorkspaceProps {
   verticalPanelGroupRef: RefObject<GroupImperativeHandle>;
   onBeginPanelDrag: (index: number, event: ReactPointerEvent<HTMLButtonElement>) => void;
   onCloseFocus: () => void;
+  onCommitFocusModalWidth: (width: number) => void;
   onFocusPanel: (index: number) => void;
   onOpenFocusedInTab: () => void;
   onRefreshProvider: (providerId: ProviderId) => void;
@@ -45,6 +77,7 @@ interface PanelWorkspaceProps {
 }
 
 export function PanelWorkspace({
+  focusModalWidth,
   focusedSlotIndex,
   googleMode,
   horizontalPanelGroupRefs,
@@ -60,6 +93,7 @@ export function PanelWorkspace({
   verticalPanelGroupRef,
   onBeginPanelDrag,
   onCloseFocus,
+  onCommitFocusModalWidth,
   onFocusPanel,
   onOpenFocusedInTab,
   onRefreshProvider,
@@ -69,6 +103,15 @@ export function PanelWorkspace({
   onResetVerticalPanelLayout,
   onSwitchPanelProvider,
 }: PanelWorkspaceProps) {
+  const { t } = useTranslation();
+  const {
+    beginResize: beginFocusResize,
+    focusModalRef,
+    leftHandleRef,
+    rightHandleRef,
+    resetWidth: resetFocusWidth,
+    width: focusWidth,
+  } = useFocusModalResize({ onCommitWidth: onCommitFocusModalWidth, width: focusModalWidth });
   const isFocusActive = focusedSlotIndex !== null;
   let slotCursor = 0;
   const mainCanvasRect = mainCanvasRef.current?.getBoundingClientRect() ?? null;
@@ -204,14 +247,20 @@ export function PanelWorkspace({
         ) : null}
         {overlayPanels.map(({ height, left, provider, slotIndex, top, width }) => {
           const isFocused = slotIndex === focusedSlotIndex;
+          // The focused modal is a single clipped container so the squircle
+          // reliably clips the iframe (splitting the clip onto a child layer
+          // breaks squircle clipping on the composited iframe and adds lag).
+          // It is centred with left/top calc rather than a CSS transform:
+          // a transformed ancestor stops Chrome clipping a composited iframe to
+          // the border-radius/squircle (corners show through once it paints).
+          const widthExpr = getFocusModalWidthStyle(focusWidth);
           const containerStyle = isFocused
             ? {
               position: "fixed" as const,
-              top: "50%",
-              left: "50%",
-              transform: "translate(-50%, -50%)",
-              width: "min(64rem, 92vw)",
-              height: "96vh",
+              top: FOCUS_MODAL_TOP,
+              left: getFocusEdgeLeft("left", widthExpr),
+              width: widthExpr,
+              height: FOCUS_MODAL_HEIGHT,
               borderRadius: 28,
               overflow: "hidden",
               boxShadow:
@@ -219,39 +268,69 @@ export function PanelWorkspace({
             }
             : { height, left, top, width };
           return (
-            <div
-              className={`pointer-events-auto absolute ${isFocused ? "squircle z-40" : ""}`}
-              key={provider.id}
-              style={containerStyle}
-            >
-              <PanelFrame
-                dragState={
-                  panelDragSourceIndex === slotIndex
-                    ? "source"
-                    : panelDragTargetIndex === slotIndex
-                      ? "target"
-                      : "idle"
-                }
-                focused={isFocused}
-                loading={loadingProviders[provider.id] ?? true}
-                mountFrameHost={(element) =>
-                  onRegisterFrameHost(
-                    provider.id,
-                    getPanelUrl(provider, googleMode, temporaryChatEnabled),
-                    provider.name,
-                    element,
-                  )
-                }
-                onBeginReorder={(event) => onBeginPanelDrag(slotIndex, event)}
-                onOpenInTab={isFocused ? onOpenFocusedInTab : undefined}
-                onRefresh={() => onRefreshProvider(provider.id)}
-                onRemove={() => onRemovePanel(slotIndex)}
-                onSwitchProvider={(nextProviderId) => onSwitchPanelProvider(slotIndex, nextProviderId)}
-                onToggleFocus={() => onFocusPanel(slotIndex)}
-                provider={provider}
-                providerOptions={providerOptions}
-              />
-            </div>
+            <Fragment key={provider.id}>
+              <div
+                className={`pointer-events-auto absolute ${isFocused ? "squircle z-40" : ""}`}
+                ref={isFocused ? focusModalRef : undefined}
+                style={containerStyle}
+              >
+                <PanelFrame
+                  dragState={
+                    panelDragSourceIndex === slotIndex
+                      ? "source"
+                      : panelDragTargetIndex === slotIndex
+                        ? "target"
+                        : "idle"
+                  }
+                  focused={isFocused}
+                  loading={loadingProviders[provider.id] ?? true}
+                  mountFrameHost={(element) =>
+                    onRegisterFrameHost(
+                      provider.id,
+                      getPanelUrl(provider, googleMode, temporaryChatEnabled),
+                      provider.name,
+                      element,
+                    )
+                  }
+                  onBeginReorder={(event) => onBeginPanelDrag(slotIndex, event)}
+                  onOpenInTab={isFocused ? onOpenFocusedInTab : undefined}
+                  onRefresh={() => onRefreshProvider(provider.id)}
+                  onRemove={() => onRemovePanel(slotIndex)}
+                  onSwitchProvider={(nextProviderId) => onSwitchPanelProvider(slotIndex, nextProviderId)}
+                  onToggleFocus={() => onFocusPanel(slotIndex)}
+                  provider={provider}
+                  providerOptions={providerOptions}
+                />
+              </div>
+              {isFocused
+                ? // Handles are fixed siblings centred on each modal edge, so they
+                  // straddle the edge without being clipped by the modal's
+                  // overflow:hidden. Their left is repainted with the width during
+                  // a drag (see useFocusModalResize).
+                  FOCUS_HANDLES.map(({ ariaKey, ariaFallback, edge }) => (
+                    <button
+                      aria-label={t(ariaKey, ariaFallback)}
+                      className="pointer-events-auto fixed z-50 w-4 -translate-x-1/2 cursor-ew-resize bg-transparent"
+                      data-tooltip={t(
+                        "focusResizeTooltip",
+                        "Drag to resize width. Double-click to reset.",
+                      )}
+                      key={edge}
+                      onDoubleClick={resetFocusWidth}
+                      onPointerDown={(event) => beginFocusResize(edge, event)}
+                      ref={edge === "left" ? leftHandleRef : rightHandleRef}
+                      style={{
+                        left: getFocusEdgeLeft(edge, widthExpr),
+                        top: `calc(${FOCUS_MODAL_TOP} + ${FOCUS_HANDLE_INSET}px)`,
+                        height: `calc(${FOCUS_MODAL_HEIGHT} - ${FOCUS_HANDLE_INSET * 2}px)`,
+                        cursor: "ew-resize",
+                        touchAction: "none",
+                      }}
+                      type="button"
+                    />
+                  ))
+                : null}
+            </Fragment>
           );
         })}
       </div>

--- a/src/multi-panel/hooks/useFocusModalResize.ts
+++ b/src/multi-panel/hooks/useFocusModalResize.ts
@@ -1,0 +1,195 @@
+import { useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+
+import { clamp } from "@/multi-panel/lib/math";
+import { DEFAULT_FOCUS_MODAL_WIDTH } from "@/shared/lib/settings";
+
+export const FOCUS_MODAL_MIN_WIDTH = 480;
+const FOCUS_MODAL_HORIZONTAL_MARGIN = 16;
+
+export type FocusModalEdge = "left" | "right";
+
+interface UseFocusModalResizeOptions {
+  width: number;
+  onCommitWidth: (width: number) => void;
+}
+
+function clampFocusModalWidth(nextWidth: number) {
+  const maxWidth = Math.max(
+    FOCUS_MODAL_MIN_WIDTH,
+    window.innerWidth - FOCUS_MODAL_HORIZONTAL_MARGIN * 2,
+  );
+  return clamp(nextWidth, FOCUS_MODAL_MIN_WIDTH, maxWidth);
+}
+
+/** The modal's CSS width, capped to the viewport. Shared with the component. */
+export function getFocusModalWidthStyle(width: number) {
+  return `min(${width}px, calc(100vw - 32px))`;
+}
+
+/**
+ * The `left` for an element aligned to one edge of a centred box of the given
+ * width style. Used for both the modal (its left edge) and the edge handles,
+ * so the modal stays centred without a CSS transform (a transformed ancestor
+ * stops Chrome clipping a composited iframe to the squircle).
+ */
+export function getFocusEdgeLeft(edge: FocusModalEdge, widthStyle: string) {
+  const half = `(${widthStyle}) / 2`;
+  return edge === "left" ? `calc(50% - ${half})` : `calc(50% + ${half})`;
+}
+
+/**
+ * Drives the focus-modal width via edge handles. The modal stays centred and
+ * each edge grows/shrinks it symmetrically.
+ *
+ * During a drag the width + left are painted straight to the DOM via refs (no
+ * React re-render per pointer move, so the iframe-bearing panel is untouched),
+ * mirroring the composer's resize approach. React state and the persisted
+ * setting are only updated when the drag ends.
+ */
+export function useFocusModalResize({ width, onCommitWidth }: UseFocusModalResizeOptions) {
+  const [committedWidth, setCommittedWidth] = useState(width);
+  const focusModalRef = useRef<HTMLDivElement | null>(null);
+  const leftHandleRef = useRef<HTMLButtonElement | null>(null);
+  const rightHandleRef = useRef<HTMLButtonElement | null>(null);
+  const widthRef = useRef(width);
+  const resizeRef = useRef<{
+    edge: FocusModalEdge;
+    handle: HTMLElement;
+    pointerId: number;
+    startClientX: number;
+    startWidth: number;
+  } | null>(null);
+
+  // Keep the painted width aligned with the persisted value while idle.
+  useEffect(() => {
+    widthRef.current = width;
+    setCommittedWidth(width);
+  }, [width]);
+
+  function paintWidth(nextWidth: number) {
+    const widthStyle = getFocusModalWidthStyle(nextWidth);
+    const leftEdge = getFocusEdgeLeft("left", widthStyle);
+    if (focusModalRef.current) {
+      focusModalRef.current.style.width = widthStyle;
+      focusModalRef.current.style.left = leftEdge;
+    }
+    if (leftHandleRef.current) {
+      leftHandleRef.current.style.left = leftEdge;
+    }
+    if (rightHandleRef.current) {
+      rightHandleRef.current.style.left = getFocusEdgeLeft("right", widthStyle);
+    }
+  }
+
+  function addDragListeners() {
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+    window.addEventListener("pointercancel", handlePointerUp);
+    window.addEventListener("blur", handleResizeCancel);
+  }
+
+  function removeDragListeners() {
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerUp);
+    window.removeEventListener("pointercancel", handlePointerUp);
+    window.removeEventListener("blur", handleResizeCancel);
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    const activeResize = resizeRef.current;
+    if (!activeResize || activeResize.pointerId !== event.pointerId) {
+      return;
+    }
+
+    if ((event.buttons & 1) !== 1) {
+      finishResize(true);
+      return;
+    }
+
+    const deltaX = event.clientX - activeResize.startClientX;
+    const widthDelta = activeResize.edge === "right" ? deltaX * 2 : deltaX * -2;
+    const nextWidth = clampFocusModalWidth(activeResize.startWidth + widthDelta);
+    widthRef.current = nextWidth;
+    paintWidth(nextWidth);
+  }
+
+  function finishResize(persist: boolean) {
+    const activeResize = resizeRef.current;
+    if (!activeResize) {
+      return;
+    }
+
+    if (activeResize.handle.hasPointerCapture?.(activeResize.pointerId)) {
+      try {
+        activeResize.handle.releasePointerCapture(activeResize.pointerId);
+      } catch {
+        // The browser may have already released capture after a fast pointerup.
+      }
+    }
+
+    resizeRef.current = null;
+    removeDragListeners();
+
+    setCommittedWidth(widthRef.current);
+    if (persist) {
+      onCommitWidth(widthRef.current);
+    }
+  }
+
+  function handlePointerUp(event: PointerEvent) {
+    if (!resizeRef.current || resizeRef.current.pointerId !== event.pointerId) {
+      return;
+    }
+
+    finishResize(true);
+  }
+
+  function handleResizeCancel() {
+    finishResize(true);
+  }
+
+  function beginResize(edge: FocusModalEdge, event: ReactPointerEvent<HTMLElement>) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // ignore capture failures
+    }
+
+    const startWidth = clampFocusModalWidth(
+      focusModalRef.current?.offsetWidth ?? widthRef.current,
+    );
+    widthRef.current = startWidth;
+    resizeRef.current = {
+      edge,
+      handle: event.currentTarget,
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startWidth,
+    };
+    addDragListeners();
+  }
+
+  function resetWidth() {
+    widthRef.current = DEFAULT_FOCUS_MODAL_WIDTH;
+    paintWidth(DEFAULT_FOCUS_MODAL_WIDTH);
+    setCommittedWidth(DEFAULT_FOCUS_MODAL_WIDTH);
+    onCommitWidth(DEFAULT_FOCUS_MODAL_WIDTH);
+  }
+
+  useEffect(() => removeDragListeners, []);
+
+  return {
+    beginResize,
+    focusModalRef,
+    leftHandleRef,
+    resetWidth,
+    rightHandleRef,
+    width: committedWidth,
+  };
+}

--- a/src/multi-panel/hooks/useFocusModalResize.ts
+++ b/src/multi-panel/hooks/useFocusModalResize.ts
@@ -161,8 +161,11 @@ export function useFocusModalResize({ width, onCommitWidth }: UseFocusModalResiz
       // ignore capture failures
     }
 
+    // offsetWidth can be 0 before the modal has laid out; fall back to the last
+    // known width rather than letting clamp snap the start to the minimum.
+    const measuredWidth = focusModalRef.current?.offsetWidth ?? 0;
     const startWidth = clampFocusModalWidth(
-      focusModalRef.current?.offsetWidth ?? widthRef.current,
+      measuredWidth > 0 ? measuredWidth : widthRef.current,
     );
     widthRef.current = startWidth;
     resizeRef.current = {

--- a/src/shared/lib/settings.ts
+++ b/src/shared/lib/settings.ts
@@ -339,7 +339,7 @@ export function normalizeSettings(input: Partial<ExtensionSettings> | null | und
 }
 
 function normalizeFocusModalWidth(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return fallback;
   }
 

--- a/src/shared/lib/settings.ts
+++ b/src/shared/lib/settings.ts
@@ -146,6 +146,7 @@ export interface ExtensionSettings {
   composerOffset: ComposerOffset;
   composerSize: ComposerSize;
   defaultComposerPosition: ComposerDefaultPosition;
+  focusModalWidth: number;
 }
 
 export type PanelProviderSlot = ProviderId | null;
@@ -168,6 +169,9 @@ export const DEFAULT_COMPOSER_OFFSET: ComposerOffset = {
 
 export const DEFAULT_COMPOSER_POSITION: ComposerDefaultPosition = "bottom";
 
+// 64rem — matches the legacy fixed focus-modal width.
+export const DEFAULT_FOCUS_MODAL_WIDTH = 1024;
+
 export const DEFAULT_SETTINGS: ExtensionSettings = {
   theme: "auto",
   language: null,
@@ -189,6 +193,7 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   composerOffset: DEFAULT_COMPOSER_OFFSET,
   composerSize: DEFAULT_COMPOSER_SIZE,
   defaultComposerPosition: DEFAULT_COMPOSER_POSITION,
+  focusModalWidth: DEFAULT_FOCUS_MODAL_WIDTH,
 };
 
 function cloneDefaults() {
@@ -326,7 +331,19 @@ export function normalizeSettings(input: Partial<ExtensionSettings> | null | und
       candidate.defaultComposerPosition === "bottom"
         ? candidate.defaultComposerPosition
         : defaults.defaultComposerPosition,
+    focusModalWidth: normalizeFocusModalWidth(
+      candidate.focusModalWidth,
+      defaults.focusModalWidth,
+    ),
   } satisfies ExtensionSettings;
+}
+
+function normalizeFocusModalWidth(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return value;
 }
 
 function normalizeComposerSize(value: unknown, fallback: ComposerSize): ComposerSize {

--- a/tests/components/PanelWorkspace.test.tsx
+++ b/tests/components/PanelWorkspace.test.tsx
@@ -1,4 +1,5 @@
 import { createRef, type MutableRefObject } from "react";
+import { fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { PanelWorkspace } from "@/multi-panel/components/PanelWorkspace";
@@ -86,5 +87,65 @@ describe("PanelWorkspace", () => {
     await user.click(getAllByRole("combobox", { name: /add chat pane to empty slot/i })[0]!);
     await user.click(getByRole("option", { name: /^Grok$/i }));
     expect(handlers.onSwitchPanelProvider).toHaveBeenCalledWith(0, "grok");
+  });
+
+  function renderFocusedWorkspace(
+    overrides: Partial<Parameters<typeof PanelWorkspace>[0]> = {},
+  ) {
+    const mainCanvasRef = makeRef({
+      getBoundingClientRect: () => ({ left: 0, top: 0 }),
+    } as HTMLElement);
+    const panelSlotRefs = makeRef({
+      0: {
+        getBoundingClientRect: () => ({
+          height: 500,
+          left: 10,
+          top: 20,
+          width: 600,
+        }),
+      } as HTMLDivElement,
+    });
+
+    return renderWorkspace({
+      focusedSlotIndex: 0,
+      mainCanvasRef,
+      panelSlotRefs,
+      slotProviders: ["chatgpt", null],
+      ...overrides,
+    });
+  }
+
+  it("renders the focused panel with both resize handles", () => {
+    const { getByRole } = renderFocusedWorkspace({ focusModalWidth: 900 });
+
+    const leftHandle = getByRole("button", { name: /resize focus view from the left edge/i });
+    getByRole("button", { name: /resize focus view from the right edge/i });
+
+    // The handles are siblings of the focused modal; the modal carries the
+    // squircle clip. (jsdom drops the CSS `min(...)` width, so the persisted
+    // value is asserted via the resize test below instead.)
+    expect(leftHandle.previousElementSibling).toHaveClass("squircle");
+  });
+
+  it("resets the focus modal width to the default on double-click", () => {
+    const { getByRole, handlers } = renderFocusedWorkspace({ focusModalWidth: 700 });
+
+    fireEvent.doubleClick(
+      getByRole("button", { name: /resize focus view from the right edge/i }),
+    );
+
+    expect(handlers.onCommitFocusModalWidth).toHaveBeenCalledWith(1024);
+  });
+
+  it("persists the focus modal width after a pointer resize", () => {
+    const { getByRole, handlers } = renderFocusedWorkspace({ focusModalWidth: 600 });
+
+    const handle = getByRole("button", { name: /resize focus view from the right edge/i });
+    fireEvent.pointerDown(handle, { button: 0, pointerId: 1, clientX: 100 });
+    fireEvent.pointerMove(window, { pointerId: 1, clientX: 150, buttons: 1 });
+    fireEvent.pointerUp(window, { pointerId: 1 });
+
+    // Right edge moves +50px, symmetric resize doubles it: 600 + 100 = 700.
+    expect(handlers.onCommitFocusModalWidth).toHaveBeenCalledWith(700);
   });
 });

--- a/tests/components/PanelWorkspace.test.tsx
+++ b/tests/components/PanelWorkspace.test.tsx
@@ -15,6 +15,7 @@ function renderWorkspace(
   const handlers = {
     onBeginPanelDrag: vi.fn(),
     onCloseFocus: vi.fn(),
+    onCommitFocusModalWidth: vi.fn(),
     onFocusPanel: vi.fn(),
     onOpenFocusedInTab: vi.fn(),
     onRefreshProvider: vi.fn(),
@@ -27,6 +28,7 @@ function renderWorkspace(
 
   const utils = renderWithProviders(
     <PanelWorkspace
+      focusModalWidth={1024}
       focusedSlotIndex={null}
       googleMode="ai"
       horizontalPanelGroupRefs={makeRef({})}

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -94,6 +94,19 @@ describe("settings", () => {
     );
   });
 
+  it("normalizes the focus modal width", () => {
+    expect(normalizeSettings({ focusModalWidth: 960 }).focusModalWidth).toBe(960);
+    expect(normalizeSettings({ focusModalWidth: "wide" as never }).focusModalWidth).toBe(
+      DEFAULT_SETTINGS.focusModalWidth,
+    );
+    expect(normalizeSettings({ focusModalWidth: 0 }).focusModalWidth).toBe(
+      DEFAULT_SETTINGS.focusModalWidth,
+    );
+    expect(normalizeSettings({ focusModalWidth: -200 }).focusModalWidth).toBe(
+      DEFAULT_SETTINGS.focusModalWidth,
+    );
+  });
+
   it("falls back to the default connector overlay setting", () => {
     expect(normalizeSettings({ connectorOverlayEnabled: "yes" as never })).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

Adds a resizable focused-panel (focus modal) whose width persists across sessions. This is the **A** implementation of the feature, chosen over the alternative `codex/focused-overlay-resize` branch after a side-by-side review.

### Why this approach

- **Single clipped container, no transform** — the modal is centred via `left: calc(50% ± width/2)` instead of a CSS `transform`. A transformed ancestor stops Chrome clipping the composited provider iframe to the squircle/border-radius, so this keeps the rounded corners intact.
- **Ref-paint during drag** — width/left are written straight to the DOM via refs, so there is no React re-render per pointer move and the iframe-bearing panel is untouched (mirrors the composer resize approach).
- **Two-edge handles** — resize symmetrically from either edge; double-click resets to the default width.
- **Idiomatic i18n** — uses the `useTranslation()` hook like the rest of the component tree.

### Ported from the alternative branch

- Reject non-positive persisted `focusModalWidth` in `normalizeSettings`, so a corrupt/zero stored value falls back to the default instead of rendering a zero-width panel.
- Fix the drag start width: `offsetWidth` can be `0` before layout and `??` does not catch `0`, which snapped the start to the minimum — now falls back to the last known width.
- Tests for width normalization and the resize handles (render, double-click reset, pointer-drag persist).

## Testing

- `bunx tsc --noEmit` — clean
- `bun run test` — 466 passed
