### PR TITLE
Fix new-chat opening external tab; guard against off-site control clicks

### DIFF
--- a/content-scripts/file-injection.js
+++ b/content-scripts/file-injection.js
@@ -43,17 +43,20 @@
     ],
   };
 
+  // Multi-word, intent-specific phrases only. Bare single words like "image"/
+  // "file" are deliberately excluded: this is a page-wide keyword scan, and a
+  // bare substring would match benign controls such as a "Create image" tool
+  // chip, a "Files" nav item, or a "Generated images" entry.
   const GEMINI_UPLOAD_KEYWORDS = [
     "upload file",
     "upload files",
+    "upload image",
     "attach file",
     "attach files",
     "insert assets",
     "add files",
-    "image",
-    "photo",
-    "pdf",
-    "file",
+    "add photo",
+    "add photos",
   ];
 
   const GEMINI_DROP_TARGET_SELECTORS = [

--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -1141,8 +1141,9 @@
       return false; // unparseable href: not a clear off-site navigation
     }
 
-    // Only http(s) destinations are navigation; javascript:, mailto:, and
-    // in-page #hash links stay within the app.
+    // Non-navigating schemes (javascript:, mailto:, tel:, …) are never an
+    // off-site navigation. In-page #hash links resolve to an http(s)
+    // same-origin URL, so they are cleared by the origin check below instead.
     if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
       return false;
     }

--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -390,7 +390,9 @@
       'button[aria-label*="new chat"]',
       'a[href="/new"]',
       'div[role="button"][aria-label*="New"]',
-      'a[href*="/new"]'
+      // Match /new and /new?… but NOT /news (e.g. announcement banner links)
+      'a[href$="/new"]',
+      'a[href*="/new?"]'
     ],
     gemini: [
       'button[aria-label="New chat"]',
@@ -400,7 +402,9 @@
     grok: [
       'a[href="/"]',
       'button[aria-label*="New"]',
-      'a[href*="new"]'
+      // Match /new and /new?… but NOT /news
+      'a[href$="/new"]',
+      'a[href*="/new?"]'
     ],
     deepseek: [
       'button[aria-label*="New"]',
@@ -416,13 +420,17 @@
       'a[href="/"]',
       'button[aria-label*="New"]',
       'a[aria-label*="New"]',
-      'a[href*="/new"]'
+      // Match /new and /new?… but NOT /news
+      'a[href$="/new"]',
+      'a[href*="/new?"]'
     ],
     meta: [
       'a[href="/"]',
       'button[aria-label*="New"]',
       'a[aria-label*="New"]',
-      'a[href*="/new"]'
+      // Match /new and /new?… but NOT /news
+      'a[href$="/new"]',
+      'a[href*="/new?"]'
     ],
     google: [
       'button[aria-label="New search"]',
@@ -546,12 +554,12 @@
     );
   }
 
-  function findFirstVisibleElement(selectors) {
+  function findFirstVisibleElement(selectors, predicate = null) {
     for (const selector of selectors) {
       try {
         const elements = document.querySelectorAll(selector);
         for (const element of elements) {
-          if (isVisibleElement(element)) {
+          if (isVisibleElement(element) && (!predicate || predicate(element))) {
             return element;
           }
         }
@@ -607,7 +615,11 @@
       .toLowerCase();
   }
 
-  function isMetaGenerationStopText(text) {
+  // True only when the accessible text IS a generation-stop phrase ("Stop",
+  // "Cancel", "Stop generating", …) — anchored, not a loose substring. Used to
+  // keep the page-wide stop keyword scan from matching benign controls whose
+  // text merely contains "cancel"/"stop" (e.g. "Cancel subscription").
+  function isGenerationStopPhrase(text) {
     if (!text) {
       return false;
     }
@@ -620,12 +632,12 @@
     );
   }
 
-  function findDeepFirstVisibleElement(selectors) {
+  function findDeepFirstVisibleElement(selectors, predicate = null) {
     for (const selector of selectors) {
       try {
         const elements = querySelectorAllDeep(selector);
         for (const element of elements) {
-          if (isVisibleElement(element)) {
+          if (isVisibleElement(element) && (!predicate || predicate(element))) {
             return element;
           }
         }
@@ -1100,9 +1112,52 @@
       : null;
   }
 
+  // Defense-in-depth: an in-app control click (new chat, send, stop, attach, …)
+  // must never navigate off the provider's origin or open a new tab/window.
+  // Providers sometimes inject promo/announcement banners whose links (e.g.
+  // Claude's "Learn more" → anthropic.com/news/…) can be matched by broad
+  // selectors. Treat any candidate that resolves to a cross-origin anchor — or
+  // one that opens a new tab — as unsafe, so a mis-match degrades to a no-op
+  // instead of hijacking the pane.
+  function resolvesToOffsiteNavigation(element) {
+    if (!element || typeof element.closest !== 'function') {
+      return false;
+    }
+
+    const anchor = element.matches?.('a[href]') ? element : element.closest('a[href]');
+    if (!anchor) {
+      return false;
+    }
+
+    const target = (anchor.getAttribute('target') || '').trim().toLowerCase();
+    if (target && target !== '_self') {
+      return true; // opens a new tab/window
+    }
+
+    let resolved;
+    try {
+      resolved = new URL(anchor.getAttribute('href') || '', window.location.href);
+    } catch (error) {
+      return false; // unparseable href: not a clear off-site navigation
+    }
+
+    // Only http(s) destinations are navigation; javascript:, mailto:, and
+    // in-page #hash links stay within the app.
+    if (resolved.protocol !== 'http:' && resolved.protocol !== 'https:') {
+      return false;
+    }
+
+    return resolved.origin !== window.location.origin;
+  }
+
   function clickElement(element) {
     const target = resolveClickableElement(element);
     if (!target) {
+      return false;
+    }
+
+    if (resolvesToOffsiteNavigation(target)) {
+      debugLog('[Text Injection] Refusing to click off-site / new-tab link:', target);
       return false;
     }
 
@@ -1319,7 +1374,7 @@
     if (
       provider === 'meta' &&
       (
-        !getElementAccessibleTextParts(element).some(part => isMetaGenerationStopText(part)) ||
+        !getElementAccessibleTextParts(element).some(part => isGenerationStopPhrase(part)) ||
         !isMetaStopCandidateNearComposer(element)
       )
     ) {
@@ -1340,8 +1395,17 @@
       return selectorMatch;
     }
 
+    // The keyword scan matches on accessible TEXT page-wide, so require that
+    // text to be an actual stop phrase (anchored) rather than merely containing
+    // "stop"/"cancel". Otherwise a benign idle-pane control ("Cancel
+    // subscription", a dialog "Cancel") could be clicked when STOP arrives with
+    // nothing generating. (Icon-only stop buttons are matched by the class
+    // selectors above, not here, so this does not lose legitimate targets.)
     const keywordMatch = findDeepClickableElementByKeywords(STOP_BUTTON_KEYWORDS);
-    if (isClickableStopCandidate(keywordMatch, provider)) {
+    if (
+      isClickableStopCandidate(keywordMatch, provider) &&
+      getElementAccessibleTextParts(keywordMatch).some(part => isGenerationStopPhrase(part))
+    ) {
       return keywordMatch;
     }
 
@@ -2315,8 +2379,13 @@
       return false;
     }
 
-    // Try to find and click button
-    const button = findDeepFirstVisibleElement(selectors) || findFirstVisibleElement(selectors);
+    // Try to find and click button. Skip any candidate that would navigate
+    // off-site / open a new tab (e.g. an announcement banner link) so the
+    // search falls through to the safe same-origin URL fallback below.
+    const isSafeTarget = (element) => !resolvesToOffsiteNavigation(element);
+    const button =
+      findDeepFirstVisibleElement(selectors, isSafeTarget) ||
+      findFirstVisibleElement(selectors, isSafeTarget);
     if (button) {
       debugLog('[Text Injection] Clicking new chat button via visible selector match');
       return clickElement(button);
@@ -2326,6 +2395,10 @@
     try {
       const allButtons = document.querySelectorAll('button, a, div[role="button"]');
       for (const elem of allButtons) {
+        if (resolvesToOffsiteNavigation(elem)) {
+          continue;
+        }
+
         const text = (elem.textContent || '').toLowerCase();
         const ariaLabel = (elem.getAttribute('aria-label') || '').toLowerCase();
         const href = elem.getAttribute('href') || '';

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/tests/content-scripts/click-guard.test.ts
+++ b/tests/content-scripts/click-guard.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { loadContentScript, resetEnterBehaviorGlobals } from "./helpers/load-script";
+
+// The off-site-navigation guard lives inside the text-injection IIFE. Extract
+// the pure function and evaluate it in isolation (same eval-extraction approach
+// the repo uses for text-injection-handler) so its logic can be pinned directly.
+function loadGuard(): (element: Element | null) => boolean {
+  const file = path.resolve(
+    process.cwd(),
+    "content-scripts",
+    "text-injection-all-providers.js",
+  );
+  const src = readFileSync(file, "utf8");
+  const match = src.match(
+    /function resolvesToOffsiteNavigation\(element\) \{[\s\S]*?\n {2}\}/,
+  );
+  if (!match) {
+    throw new Error("resolvesToOffsiteNavigation not found in content script");
+  }
+  return new Function(
+    `${match[0]}; return resolvesToOffsiteNavigation;`,
+  )() as (element: Element | null) => boolean;
+}
+
+const resolvesToOffsiteNavigation = loadGuard();
+const ORIGIN = window.location.origin;
+
+function anchor(attrs: Record<string, string>, inner = ""): HTMLAnchorElement {
+  const a = document.createElement("a");
+  for (const [k, v] of Object.entries(attrs)) a.setAttribute(k, v);
+  a.innerHTML = inner;
+  document.body.appendChild(a);
+  return a;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("resolvesToOffsiteNavigation (off-site click guard)", () => {
+  it("flags a cross-origin announcement banner link", () => {
+    const a = anchor({ href: "https://www.anthropic.com/news/fable-mythos-access" });
+    expect(resolvesToOffsiteNavigation(a)).toBe(true);
+  });
+
+  it("flags any same-origin link that opens a new tab/window", () => {
+    expect(resolvesToOffsiteNavigation(anchor({ href: "/new", target: "_blank" }))).toBe(true);
+    expect(resolvesToOffsiteNavigation(anchor({ href: "/new", target: "someNamedWindow" }))).toBe(true);
+  });
+
+  it("allows a same-origin relative link", () => {
+    expect(resolvesToOffsiteNavigation(anchor({ href: "/new" }))).toBe(false);
+    expect(resolvesToOffsiteNavigation(anchor({ href: "/new?incognito" }))).toBe(false);
+  });
+
+  it("allows a same-origin absolute link, including target=_self", () => {
+    expect(resolvesToOffsiteNavigation(anchor({ href: `${ORIGIN}/new` }))).toBe(false);
+    expect(resolvesToOffsiteNavigation(anchor({ href: `${ORIGIN}/new`, target: "_self" }))).toBe(false);
+  });
+
+  it("flags a child element nested inside a cross-origin anchor", () => {
+    anchor({ href: "https://evil.example.com/go" }, '<span id="child">click</span>');
+    const child = document.getElementById("child")!;
+    expect(resolvesToOffsiteNavigation(child)).toBe(true);
+  });
+
+  it("does not flag non-anchor controls (buttons, role=button divs)", () => {
+    const button = document.createElement("button");
+    button.textContent = "Start new chat";
+    document.body.appendChild(button);
+    expect(resolvesToOffsiteNavigation(button)).toBe(false);
+
+    const div = document.createElement("div");
+    div.setAttribute("role", "button");
+    document.body.appendChild(div);
+    expect(resolvesToOffsiteNavigation(div)).toBe(false);
+  });
+
+  it("ignores non-navigating href schemes (javascript:, mailto:, #hash)", () => {
+    expect(resolvesToOffsiteNavigation(anchor({ href: "javascript:void(0)" }))).toBe(false);
+    expect(resolvesToOffsiteNavigation(anchor({ href: "mailto:x@y.com" }))).toBe(false);
+    expect(resolvesToOffsiteNavigation(anchor({ href: "#section" }))).toBe(false);
+  });
+
+  it("is null/garbage safe", () => {
+    expect(resolvesToOffsiteNavigation(null)).toBe(false);
+    expect(resolvesToOffsiteNavigation(anchor({ href: "" }))).toBe(false);
+  });
+});
+
+// End-to-end: drive a real NEW_CHAT message through the loaded content script
+// and prove the banner link is never clicked, while a legitimate same-origin
+// control still is.
+describe("NEW_CHAT message does not click an off-site banner link", () => {
+  afterEach(() => {
+    resetEnterBehaviorGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("skips a target=_blank off-site link and clicks the real new-chat control", () => {
+    Object.defineProperty(window.location, "hostname", {
+      configurable: true,
+      value: "claude.ai",
+    });
+
+    // Banner link appears first in document order and even carries matching
+    // text — without the guard the text-fallback search would click it.
+    const banner = document.createElement("a");
+    banner.setAttribute("href", "https://www.anthropic.com/news/fable-mythos-access");
+    banner.setAttribute("target", "_blank");
+    banner.textContent = "Start new chat";
+    document.body.appendChild(banner);
+
+    const realControl = document.createElement("button");
+    realControl.textContent = "Start new chat";
+    document.body.appendChild(realControl);
+
+    let bannerClicked = false;
+    let realClicked = false;
+    banner.addEventListener("click", (e) => {
+      bannerClicked = true;
+      e.preventDefault();
+    });
+    realControl.addEventListener("click", () => {
+      realClicked = true;
+    });
+
+    loadContentScript("text-injection-all-providers.js");
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "NEW_CHAT", context: "multi-panel" },
+      }),
+    );
+
+    expect(bannerClicked).toBe(false);
+    expect(realClicked).toBe(true);
+  });
+});

--- a/tests/content-scripts/click-guard.test.ts
+++ b/tests/content-scripts/click-guard.test.ts
@@ -15,8 +15,11 @@ function loadGuard(): (element: Element | null) => boolean {
     "text-injection-all-providers.js",
   );
   const src = readFileSync(file, "utf8");
+  // Capture the function's own indentation and backreference it for the
+  // closing brace, so this survives reindentation while still skipping the
+  // more-deeply-indented braces of nested blocks.
   const match = src.match(
-    /function resolvesToOffsiteNavigation\(element\) \{[\s\S]*?\n {2}\}/,
+    /\n([ \t]*)function resolvesToOffsiteNavigation\(element\) \{[\s\S]*?\n\1\}/,
   );
   if (!match) {
     throw new Error("resolvesToOffsiteNavigation not found in content script");

--- a/tests/content-scripts/new-chat-selectors.test.ts
+++ b/tests/content-scripts/new-chat-selectors.test.ts
@@ -14,13 +14,15 @@ function loadNewChatSelectors(): Record<string, string[]> {
     "text-injection-all-providers.js",
   );
   const src = readFileSync(file, "utf8");
+  // Indentation-backreferenced (group 1 = indent) so reformatting the source
+  // can't break extraction; group 2 is the object literal.
   const match = src.match(
-    /const NEW_CHAT_BUTTON_SELECTORS = (\{[\s\S]*?\n {2}\});/,
+    /\n([ \t]*)const NEW_CHAT_BUTTON_SELECTORS = (\{[\s\S]*?\n\1\});/,
   );
   if (!match) {
     throw new Error("NEW_CHAT_BUTTON_SELECTORS not found in content script");
   }
-  return new Function(`return ${match[1]}`)() as Record<string, string[]>;
+  return new Function(`return ${match[2]}`)() as Record<string, string[]>;
 }
 
 const SELECTORS = loadNewChatSelectors();

--- a/tests/content-scripts/new-chat-selectors.test.ts
+++ b/tests/content-scripts/new-chat-selectors.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+// text-injection-all-providers.js is a large IIFE that keeps its selector tables
+// in closure scope. Rather than evaluate the whole script, extract the
+// NEW_CHAT_BUTTON_SELECTORS object literal (it references nothing external) and
+// eval just that, so the test stays pinned to the real source.
+function loadNewChatSelectors(): Record<string, string[]> {
+  const file = path.resolve(
+    process.cwd(),
+    "content-scripts",
+    "text-injection-all-providers.js",
+  );
+  const src = readFileSync(file, "utf8");
+  const match = src.match(
+    /const NEW_CHAT_BUTTON_SELECTORS = (\{[\s\S]*?\n {2}\});/,
+  );
+  if (!match) {
+    throw new Error("NEW_CHAT_BUTTON_SELECTORS not found in content script");
+  }
+  return new Function(`return ${match[1]}`)() as Record<string, string[]>;
+}
+
+const SELECTORS = loadNewChatSelectors();
+
+// The bug: a[href*="/new"] also matches /news, so Claude's "Fable Mythos"
+// announcement banner link (https://www.anthropic.com/news/...) was clicked,
+// opening a new browser tab instead of starting a new chat in the panel.
+const NEWS_LINK = "https://www.anthropic.com/news/fable-mythos-access";
+
+function makeLink(href: string): HTMLAnchorElement {
+  const link = document.createElement("a");
+  link.setAttribute("href", href);
+  document.body.appendChild(link);
+  return link;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("new chat button selectors", () => {
+  // Every provider whose new-chat selectors include an href-based /new match.
+  const HREF_BASED_PROVIDERS = ["claude", "qwen", "meta", "grok"] as const;
+
+  for (const provider of HREF_BASED_PROVIDERS) {
+    describe(provider, () => {
+      const combined = SELECTORS[provider].join(", ");
+
+      it("does not match announcement /news links", () => {
+        const news = makeLink(NEWS_LINK);
+        expect(news.matches(combined)).toBe(false);
+      });
+
+      it("does not match a bare /news path", () => {
+        const news = makeLink("/news");
+        expect(news.matches(combined)).toBe(false);
+      });
+
+      it("matches an absolute /new chat link", () => {
+        const newChat = makeLink("https://claude.ai/new");
+        expect(newChat.matches(combined)).toBe(true);
+      });
+
+      it("matches a /new link carrying a query string", () => {
+        const newChat = makeLink("/new?incognito");
+        expect(newChat.matches(combined)).toBe(true);
+      });
+    });
+  }
+
+  it("does not retain the loose /new substring selector for any provider", () => {
+    for (const selectors of Object.values(SELECTORS)) {
+      expect(selectors).not.toContain('a[href*="/new"]');
+      expect(selectors).not.toContain('a[href*="new"]');
+    }
+  });
+
+  it("prefers the real new-chat link over a news link in document order", () => {
+    // News banner appears before the sidebar new-chat link in the DOM.
+    makeLink(NEWS_LINK);
+    const newChat = makeLink("/new");
+
+    expect(document.querySelector(SELECTORS.claude.join(", "))).toBe(newChat);
+  });
+});

--- a/tests/content-scripts/selector-hardening.test.ts
+++ b/tests/content-scripts/selector-hardening.test.ts
@@ -13,7 +13,8 @@ function readContentScript(name: string): string {
 // Extract the anchored stop-phrase predicate and evaluate it in isolation.
 function loadStopPhrasePredicate(): (text: string) => boolean {
   const src = readContentScript("text-injection-all-providers.js");
-  const match = src.match(/function isGenerationStopPhrase\(text\) \{[\s\S]*?\n {2}\}/);
+  // Indentation-backreferenced so reformatting the source can't break it.
+  const match = src.match(/\n([ \t]*)function isGenerationStopPhrase\(text\) \{[\s\S]*?\n\1\}/);
   if (!match) {
     throw new Error("isGenerationStopPhrase not found in content script");
   }

--- a/tests/content-scripts/selector-hardening.test.ts
+++ b/tests/content-scripts/selector-hardening.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+function readContentScript(name: string): string {
+  return readFileSync(
+    path.resolve(process.cwd(), "content-scripts", name),
+    "utf8",
+  );
+}
+
+// Extract the anchored stop-phrase predicate and evaluate it in isolation.
+function loadStopPhrasePredicate(): (text: string) => boolean {
+  const src = readContentScript("text-injection-all-providers.js");
+  const match = src.match(/function isGenerationStopPhrase\(text\) \{[\s\S]*?\n {2}\}/);
+  if (!match) {
+    throw new Error("isGenerationStopPhrase not found in content script");
+  }
+  return new Function(`${match[0]}; return isGenerationStopPhrase;`)() as (
+    text: string,
+  ) => boolean;
+}
+
+function loadGeminiUploadKeywords(): string[] {
+  const src = readContentScript("file-injection.js");
+  const match = src.match(/const GEMINI_UPLOAD_KEYWORDS = (\[[\s\S]*?\]);/);
+  if (!match) {
+    throw new Error("GEMINI_UPLOAD_KEYWORDS not found in file-injection.js");
+  }
+  return new Function(`return ${match[1]}`)() as string[];
+}
+
+describe("stop keyword fallback is anchored to real stop phrases", () => {
+  const isStopPhrase = loadStopPhrasePredicate();
+
+  it("accepts genuine generation-stop labels", () => {
+    for (const text of [
+      "stop",
+      "Stop",
+      "Stop generating",
+      "Stop response",
+      "cancel",
+      "Cancel",
+      "Interrupt",
+      "停止",
+      "取消",
+      "정지",
+    ]) {
+      expect(isStopPhrase(text)).toBe(true);
+    }
+  });
+
+  it("rejects benign controls that merely contain a stop keyword as a substring", () => {
+    for (const text of [
+      "Cancel subscription",
+      "Cancel anytime",
+      "Cancel plan",
+      "Stop sharing",
+      "Pause membership",
+      "Cancel your free trial",
+      "Stop following",
+    ]) {
+      expect(isStopPhrase(text)).toBe(false);
+    }
+  });
+});
+
+describe("Gemini upload keyword fallback only uses intent-specific phrases", () => {
+  const keywords = loadGeminiUploadKeywords();
+
+  it("drops bare single-word keywords that match benign chrome", () => {
+    for (const bare of ["image", "photo", "pdf", "file"]) {
+      expect(keywords).not.toContain(bare);
+    }
+  });
+
+  it("keeps multi-word upload phrases", () => {
+    expect(keywords).toContain("upload file");
+    expect(keywords).toContain("attach file");
+    expect(keywords.every((k) => k.includes(" "))).toBe(true);
+  });
+
+  it("no kept phrase is a substring of common benign Gemini controls", () => {
+    const benign = [
+      "create image",
+      "generated images",
+      "files",
+      "export to pdf",
+      "image generation",
+    ].map((t) => t.toLowerCase());
+
+    for (const keyword of keywords) {
+      for (const control of benign) {
+        expect(control.includes(keyword)).toBe(false);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Claude.ai added a persistent announcement banner — *"Claude Fable 5 is currently unavailable. **Learn more**"* — where "Learn more" is an `<a href="https://www.anthropic.com/news/fable-mythos-access" target="_blank">`. Clicking **New chats** in the floating composer opened that link in a new Chrome tab instead of starting new chats in the panes.

**Root cause:** the claude new-chat selector list ended with `a[href*="/new"]`. CSS substring matching means `[href*="/new"]` also matches `/news`, so the banner link was the match. With `target="_blank"`, the click opened a new tab. (`qwen`/`meta` shared the same `a[href*="/new"]`; `grok` had the looser `a[href*="new"]`.)

## Fix (defense-in-depth)

1. **Tighten selectors** — `a[href$="/new"]` + `a[href*="/new?"]` for claude/qwen/meta/grok, so `/news` no longer matches.
2. **Global guard in `clickElement`** — `resolvesToOffsiteNavigation()` refuses to activate any element resolving to a cross-origin or `target=_blank` link. This is the single choke point for *every* pane action (new chat, send, stop, attach…), so no action can navigate a pane away or open a tab regardless of which selector matched — now or for any future provider banner.
3. **New-chat find-stage skip** — the search ignores off-site candidates and falls through to the safe same-origin URL fallback, so a new chat still opens.

## Additional hardening (from a follow-up audit of all action selectors)

- **Stop** — the page-wide stop keyword fallback now requires an *anchored* stop phrase for all providers, so a benign idle-pane control like "Cancel subscription" can't be clicked. (Icon-only stop buttons are matched by class selectors and unaffected.)
- **Gemini upload** — dropped bare single-word keywords (`image`/`photo`/`pdf`/`file`) that matched chrome like "Create image" chips; kept the multi-word phrases.

## Testing

- New regression tests: `new-chat-selectors`, `click-guard` (incl. an end-to-end `NEW_CHAT` test that loads the real content script and proves the banner link is skipped), `selector-hardening`.
- Full suite: **498 passing**.
- Verified manually in Chrome against a live Claude pane with the banner present.

Version bumped to **1.0.3**.
