### PR TITLE
Add interactive onboarding tour

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -82,8 +82,16 @@ function getSelectedTextFromContext(info) {
   );
 }
 
-chrome.runtime.onInstalled.addListener(async () => {
+chrome.runtime.onInstalled.addListener(async (details) => {
   await createContextMenus();
+
+  // On a fresh install, open the workspace so the first-run onboarding tour
+  // greets the user immediately. The tour itself decides whether to show based
+  // on its own version-gated state in chrome.storage.local (see
+  // src/multi-panel/onboarding/onboarding-storage.ts) — we only open the tab.
+  if (details?.reason === "install") {
+    await openMultiPanel();
+  }
 });
 
 chrome.runtime.onStartup.addListener(async () => {

--- a/src/multi-panel/App.tsx
+++ b/src/multi-panel/App.tsx
@@ -16,6 +16,8 @@ import { selectFirstPromptBlank } from "@/multi-panel/components/HighlightedComp
 import { LayoutModal } from "@/multi-panel/components/LayoutModal";
 import { PanelWorkspace } from "@/multi-panel/components/PanelWorkspace";
 import { SettingsModal } from "@/multi-panel/components/SettingsModal";
+import { OnboardingTour } from "@/multi-panel/onboarding/OnboardingTour";
+import { useOnboardingTour } from "@/multi-panel/onboarding/useOnboardingTour";
 import { useComposerDraftController } from "@/multi-panel/hooks/useComposerDraftController";
 import { useComposerFrameController } from "@/multi-panel/hooks/useComposerFrameController";
 import { useConnectorController } from "@/multi-panel/hooks/useConnectorController";
@@ -283,6 +285,18 @@ export function App() {
   const { urlByProvider } = useProviderUrlTracker({ frameRefs });
   const { titleByProvider } = useProviderTitleTracker({ frameRefs });
 
+  const onboardingTour = useOnboardingTour({
+    ready: loaded && isHydrated,
+    context: {
+      activePanelCount: slotProviders.filter(Boolean).length,
+      promptQuickPickOpen,
+    },
+    actions: {
+      openPromptQuickPick: () => setPromptQuickPickOpen(true),
+      closePromptQuickPick: () => setPromptQuickPickOpen(false),
+    },
+  });
+
   useEffect(() => {
     const leftmostProvider = panelProviders.find((id): id is ProviderId => Boolean(id));
     if (!leftmostProvider) {
@@ -549,6 +563,10 @@ export function App() {
         onImportSettingsFile={handleImportSettingsFile}
         onReorderProvider={reorderProvider}
         onOpenPromptLibrary={() => setPromptLibraryOpen(true)}
+        onReplayTour={() => {
+          setSettingsModalOpen(false);
+          void onboardingTour.start();
+        }}
         onResetAllSettings={resetAllSettings}
         onResetComposer={resetComposerToDefaults}
         onResetLayout={handleResetLayout}
@@ -619,6 +637,8 @@ export function App() {
         prompt={variablePrompt}
         values={variableValues}
       />
+
+      <OnboardingTour tour={onboardingTour} />
     </div>
   );
 }

--- a/src/multi-panel/components/FloatingComposer.tsx
+++ b/src/multi-panel/components/FloatingComposer.tsx
@@ -262,6 +262,7 @@ export function FloatingComposer({
               }`}
             data-tooltip={t("composerBarDragHint", "Drag to reposition. Double-click to reset position.")}
             data-tooltip-placement="bottom"
+            data-tour="composer-bar"
             onDoubleClick={(event) => {
               if (isComposerBarControlTarget(event.target)) {
                 return;
@@ -308,6 +309,7 @@ export function FloatingComposer({
                 className={COMPOSER_BOTTOM_ICON_BUTTON_CLASS}
                 data-tooltip={t("composerTooltipSettings", "Settings")}
                 data-tooltip-placement="bottom"
+                data-tour="settings"
                 onClick={onOpenSettings}
                 type="button"
               >
@@ -318,6 +320,7 @@ export function FloatingComposer({
                 className={COMPOSER_BOTTOM_ICON_BUTTON_CLASS}
                 data-tooltip={t("composerTooltipLayout", "Layout")}
                 data-tooltip-placement="bottom"
+                data-tour="layout"
                 onClick={onOpenLayoutModal}
                 type="button"
               >
@@ -339,6 +342,7 @@ export function FloatingComposer({
                     onOpenPromptQuickPick();
                   }
                 }}
+                data-tour="prompt-library"
                 ref={promptLibraryButtonRef}
                 type="button"
               >
@@ -381,6 +385,7 @@ export function FloatingComposer({
                 className={COMPOSER_BOTTOM_ICON_BUTTON_CLASS}
                 data-tooltip={t("composerTooltipAddPane", "Add pane")}
                 data-tooltip-placement="bottom"
+                data-tour="add-pane"
                 onClick={onAddPanel}
                 type="button"
               >
@@ -403,6 +408,7 @@ export function FloatingComposer({
                     : t("composerAriaEnableScrollSync", "Enable scroll sync")
                 }
                 data-tooltip-placement="bottom"
+                data-tour="scroll-sync"
                 onClick={onToggleScrollSync}
                 type="button"
               >
@@ -462,6 +468,7 @@ export function FloatingComposer({
                     : t("composerAriaSendAll", "Send all")
                 }
                 className={`${COMPOSER_BOTTOM_ICON_BASE_CLASS} bg-[hsl(var(--accent-strong))] text-[hsl(var(--foreground-on-accent))] shadow-[0_10px_24px_-18px_hsl(var(--accent-strong)/0.88)] transition-transform hover:scale-[1.02]`}
+                data-tour="send-all"
                 data-tooltip={
                   stopGenerationActive
                     ? t("composerTooltipStopAllEsc", "Stop all (Esc)")

--- a/src/multi-panel/components/HighlightedComposerInput.tsx
+++ b/src/multi-panel/components/HighlightedComposerInput.tsx
@@ -221,7 +221,7 @@ export function HighlightedComposerInput({
   }
 
   return (
-    <div className="relative mr-3 mt-2.5 flex min-h-0 flex-1 flex-col">
+    <div className="relative mr-3 mt-2.5 flex min-h-0 flex-1 flex-col" data-tour="composer-input">
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 overflow-hidden px-6 pt-2.5 pb-4 text-base"

--- a/src/multi-panel/components/PanelFrame.tsx
+++ b/src/multi-panel/components/PanelFrame.tsx
@@ -89,6 +89,7 @@ export function PanelFrame({
         <PanelControlIconButton
           aria-label="Close this panel"
           danger
+          data-tour="panel-close"
           onClick={onRemove}
           tooltip="Close this panel"
         >

--- a/src/multi-panel/components/PromptQuickPickPopover.tsx
+++ b/src/multi-panel/components/PromptQuickPickPopover.tsx
@@ -123,6 +123,7 @@ export function PromptQuickPickPopover({
   return (
     <div
       className="pointer-events-auto absolute bottom-full left-1/2 z-30 mb-3 w-[min(420px,calc(100vw-32px))] -translate-x-1/2 rounded-[20px] border border-[hsl(var(--border-muted)/0.08)] bg-[hsl(var(--surface-panel))] p-3 text-sm text-[hsl(var(--foreground))]"
+      data-onboarding-popover
       onPointerDown={(event) => event.stopPropagation()}
       ref={popoverRef}
       role="dialog"
@@ -186,6 +187,7 @@ export function PromptQuickPickPopover({
       <div className="mt-2 border-t border-[hsl(var(--tint-base)/0.08)] pt-2">
         <button
           className="flex w-full items-center justify-between rounded-2xl px-3 py-2 text-xs text-[hsl(var(--foreground-soft))] transition hover:bg-[hsl(var(--tint-base)/0.06)] hover:text-[hsl(var(--foreground))]"
+          data-tour="manage-prompts"
           onClick={onOpenLibrary}
           type="button"
         >

--- a/src/multi-panel/components/SettingsModal.tsx
+++ b/src/multi-panel/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { useState, type DragEvent } from "react";
 import {
   Download,
   ExternalLink,
+  GraduationCap,
   Grid2x2X,
   GripVertical,
   ListRestart,
@@ -63,6 +64,7 @@ interface SettingsModalProps {
   onOpenPromptLibrary: () => void;
   onReorderProvider: (providerId: ProviderId, targetProviderId: ProviderId) => void | Promise<void>;
   onResetAllSettings: () => void | Promise<void>;
+  onReplayTour: () => void;
   onResetComposer: () => void;
   onResetLayout: () => void;
   onRunVersionCheck: () => void | Promise<unknown>;
@@ -97,6 +99,7 @@ export function SettingsModal({
   onImportSettingsFile,
   onOpenPromptLibrary,
   onReorderProvider,
+  onReplayTour,
   onResetAllSettings,
   onResetComposer,
   onResetLayout,
@@ -762,6 +765,20 @@ export function SettingsModal({
 
           {settingsTab === "about" ? (
             <>
+              <SettingItem
+                description={t(
+                  "aboutTutorialDescription",
+                  "Replay the interactive onboarding tour to revisit the basics anytime.",
+                )}
+                title={t("aboutTutorialTitle", "Onboarding tour")}
+                trailing={
+                  <Button onClick={onReplayTour} variant="secondary">
+                    <GraduationCap size={16} />
+                    {t("dataReplayTutorial", "Replay tutorial")}
+                  </Button>
+                }
+              />
+
               <SettingItem
                 description={t(
                   "aboutVersionDescription",

--- a/src/multi-panel/onboarding/OnboardingTour.tsx
+++ b/src/multi-panel/onboarding/OnboardingTour.tsx
@@ -1,0 +1,421 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useMemo, type CSSProperties, type ReactNode } from "react";
+
+import { Button } from "@/shared/components/Button";
+import { Modal } from "@/shared/components/Modal";
+import { useTranslation } from "@/shared/contexts/I18nContext";
+import type { OnboardingTourController } from "@/multi-panel/onboarding/useOnboardingTour";
+
+interface OnboardingTourProps {
+  tour: OnboardingTourController;
+}
+
+const CARD_WIDTH = 340;
+const CARD_MARGIN = 16;
+const HOLE_GAP = 14;
+// Matches the `rounded-2xl` (16px) highlight ring, so the dim's inner corners
+// curve in exactly under the ring instead of leaving sharp bits poking out.
+const HOLE_RADIUS = 16;
+const DIM_COLOR = "hsl(var(--shadow-ambient)/0.55)";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+const dimClass = "absolute bg-[hsl(var(--shadow-ambient)/0.55)]";
+
+const CONFETTI_COLORS = [
+  "#f97316",
+  "#22c55e",
+  "#3b82f6",
+  "#eab308",
+  "#ec4899",
+  "#a855f7",
+  "#14b8a6",
+];
+
+// A no-library confetti burst whose pieces drive the `onboarding-confetti-fall`
+// keyframes via inline CSS custom properties (see globals.css). Built once with
+// useMemo so the random spread stays stable across re-renders.
+function ConfettiBurst() {
+  const pieces = useMemo(
+    () =>
+      Array.from({ length: 90 }, (_, index) => {
+        const round = Math.random() < 0.3;
+        const size = 6 + Math.round(Math.random() * 5);
+        return {
+          left: Math.random() * 100,
+          width: size,
+          height: round ? size : 10 + Math.round(Math.random() * 8),
+          round,
+          color: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+          drift: Math.round((Math.random() * 2 - 1) * 170),
+          spin: Math.round(360 + Math.random() * 720),
+          duration: (1.6 + Math.random()).toFixed(2),
+          delay: (Math.random() * 0.5).toFixed(2),
+        };
+      }),
+    [],
+  );
+
+  return (
+    <>
+      {pieces.map((piece, index) => (
+        <span
+          key={index}
+          className="onboarding-confetti-piece"
+          style={
+            {
+              left: `${piece.left}%`,
+              width: piece.width,
+              height: piece.height,
+              borderRadius: piece.round ? 9999 : 2,
+              background: piece.color,
+              "--confetti-drift": `${piece.drift}px`,
+              "--confetti-spin": `${piece.spin}deg`,
+              "--confetti-duration": `${piece.duration}s`,
+              "--confetti-delay": `${piece.delay}s`,
+            } as CSSProperties
+          }
+        />
+      ))}
+    </>
+  );
+}
+
+// Representative layouts shown in the step-4 "sneak peek" (rows × cols).
+const LAYOUT_PEEKS = [
+  { label: "1×3", rows: 1, cols: 3 },
+  { label: "2×2", rows: 2, cols: 2 },
+  { label: "3×3", rows: 3, cols: 3 },
+];
+
+// A tiny non-interactive thumbnail of a layout: a grid of placeholder cells.
+function LayoutMiniPreview({ rows, cols }: { rows: number; cols: number }) {
+  return (
+    <div
+      className="grid gap-[3px] rounded-md bg-[hsl(var(--tint-base)/0.06)] p-1 ring-1 ring-[hsl(var(--tint-ring)/0.10)]"
+      style={{
+        width: 66,
+        height: 46,
+        gridTemplateColumns: `repeat(${cols}, 1fr)`,
+        gridTemplateRows: `repeat(${rows}, 1fr)`,
+      }}
+    >
+      {Array.from({ length: rows * cols }, (_, index) => (
+        <div key={index} className="rounded-[3px] bg-[hsl(var(--foreground)/0.2)]" />
+      ))}
+    </div>
+  );
+}
+
+// A small "sneak peek" panel that floats above the Layout step's card, giving a
+// feel for the layout picker (1×3, 2×2, 3×3) without opening the full menu.
+function LayoutShowcase() {
+  const { t } = useTranslation();
+  return (
+    <div
+      className="pointer-events-none squircle rounded-[20px] border border-[hsl(var(--border-muted)/0.12)] bg-[hsl(var(--surface-modal))] px-4 py-3 shadow-[0_24px_80px_-32px_hsl(var(--shadow-ambient)/0.95)]"
+      data-tour-showcase="layouts"
+    >
+      <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-[hsl(var(--foreground-muted))]">
+        {t("onboardingLayoutPeekTitle", "Layouts at a glance")}
+      </p>
+      <div className="mt-2 flex items-end justify-center gap-3">
+        {LAYOUT_PEEKS.map((peek) => (
+          <div key={peek.label} className="flex flex-col items-center gap-1.5">
+            <LayoutMiniPreview rows={peek.rows} cols={peek.cols} />
+            <span className="text-[11px] font-medium text-[hsl(var(--foreground-soft))]">
+              {peek.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function OnboardingTour({ tour }: OnboardingTourProps) {
+  const { t } = useTranslation();
+  const { phase, step, stepIndex, stepCount, targetRect, cardRect, activeTooltip, reducedMotion } =
+    tour;
+
+  if (phase === "idle") {
+    return null;
+  }
+
+  if (phase === "welcome") {
+    return (
+      <Modal
+        open
+        onClose={tour.skip}
+        size="md"
+        title={t("onboardingWelcomeTitle", "Welcome to Parallel AI")}
+        description={t(
+          "onboardingWelcomeBody",
+          "Run ChatGPT, Claude, Gemini and more side by side. Take a 60-second tour of the essentials?",
+        )}
+        actions={
+          <div className="flex justify-end gap-2">
+            <Button variant="ghost" onClick={tour.skip}>
+              {t("onboardingSkip", "Skip")}
+            </Button>
+            <Button variant="primary" onClick={tour.next}>
+              {t("onboardingStart", "Start tour")}
+            </Button>
+          </div>
+        }
+      >
+        <p className="text-sm text-[hsl(var(--foreground-soft))]">
+          {t("onboardingWelcomeHint", "You can replay this tutorial anytime from:")}
+          <span className="pt-4 block text-center font-bold text-[hsl(var(--accent-strong))]">
+            {t("onboardingWelcomeHintPath", "Settings → About → Onboarding tour")}
+          </span>
+        </p>
+      </Modal>
+    );
+  }
+
+  if (phase === "finish") {
+    // No dialog — just a celebratory confetti flourish + "You're all set!" that
+    // plays over the workspace and auto-dismisses (the controller closes it).
+    return (
+      <div
+        className="pointer-events-none fixed inset-0 z-[70] overflow-hidden"
+        data-onboarding-phase="finish"
+      >
+        {reducedMotion ? null : <ConfettiBurst />}
+        <div
+          className={`absolute left-1/2 top-1/2 ${reducedMotion ? "-translate-x-1/2 -translate-y-1/2" : "onboarding-celebrate"
+            }`}
+        >
+          <span className="squircle whitespace-nowrap rounded-full bg-[hsl(var(--surface-modal)/0.92)] px-7 py-3 text-2xl font-semibold text-[hsl(var(--foreground))] shadow-[0_18px_50px_-24px_hsl(var(--shadow-ambient)/0.92)] backdrop-blur-sm">
+            {t("onboardingFinishTitle", "You're all set!")}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // phase === "step"
+  if (!step) {
+    return null;
+  }
+
+  const isAction = step.advance === "action";
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  // Until the first measurement lands, dim the whole screen (no hole yet).
+  if (!targetRect) {
+    return (
+      <div
+        className="pointer-events-none fixed inset-0 z-40"
+        data-onboarding-phase={phase}
+      >
+        <div className={`${dimClass} pointer-events-auto inset-0`} />
+      </div>
+    );
+  }
+
+  const pad = step.spotlightPadding ?? 8;
+  const hole = {
+    left: Math.max(0, targetRect.left - pad),
+    top: Math.max(0, targetRect.top - pad),
+    right: Math.min(vw, targetRect.right + pad),
+    bottom: Math.min(vh, targetRect.bottom + pad),
+  };
+  const holeWidth = Math.max(0, hole.right - hole.left);
+  const holeHeight = Math.max(0, hole.bottom - hole.top);
+
+  // The card can anchor to a different element than the spotlight (e.g. ring the
+  // "Manage…" row but sit above the whole popover so it never covers the search).
+  // cardRect is measured by the controller's rAF loop (see useOnboardingTour).
+  const refTop = cardRect ? cardRect.top : hole.top;
+  const refBottom = cardRect ? cardRect.bottom : hole.bottom;
+  const refCenterX = cardRect
+    ? cardRect.left + cardRect.width / 2
+    : targetRect.left + targetRect.width / 2;
+
+  const placeBelow =
+    step.placement === "bottom" || (step.placement !== "top" && refTop < vh * 0.45);
+  const centerX = clamp(
+    refCenterX,
+    CARD_MARGIN + CARD_WIDTH / 2,
+    vw - CARD_MARGIN - CARD_WIDTH / 2,
+  );
+  // For the "above" case, pin the card's BOTTOM edge with `bottom` (rather than
+  // top + translateY) so it reliably grows upward and clears the anchor. The
+  // unused offset is set to "auto" so no stale top/bottom lingers across steps.
+  const cardStyle: CSSProperties = {
+    left: centerX,
+    transform: "translateX(-50%)",
+    ...(placeBelow
+      ? { top: refBottom + HOLE_GAP, bottom: "auto" }
+      : { bottom: Math.max(CARD_MARGIN, vh - (refTop - HOLE_GAP)), top: "auto" }),
+  };
+
+  const transitionClass = reducedMotion ? "" : "transition-all duration-200 ease-out";
+
+  // The highlighted control's own tooltip, in its normal position — reuses the
+  // app-tooltip styling so it matches a real hover. Guarded because activeTooltip
+  // is null on every step without a control tooltip.
+  let tooltipNode: ReactNode = null;
+  if (activeTooltip) {
+    const placement = activeTooltip.placement ?? (targetRect.top > 44 ? "top" : "bottom");
+    const ttX = clamp(targetRect.left + targetRect.width / 2, 12, vw - 12);
+    const ttY = placement === "top" ? targetRect.top - 8 : targetRect.bottom + 8;
+    tooltipNode = (
+      <div
+        className={`app-tooltip app-tooltip--${placement}`}
+        role="tooltip"
+        style={{ left: ttX, top: ttY }}
+      >
+        {activeTooltip.text}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-40"
+      data-onboarding-phase={phase}
+    >
+      {/* Four dimmers framing the spotlight hole. */}
+      <div
+        className={`${dimClass} pointer-events-auto`}
+        style={{ left: 0, top: 0, width: vw, height: hole.top }}
+      />
+      <div
+        className={`${dimClass} pointer-events-auto`}
+        style={{ left: 0, top: hole.bottom, width: vw, height: Math.max(0, vh - hole.bottom) }}
+      />
+      <div
+        className={`${dimClass} pointer-events-auto`}
+        style={{ left: 0, top: hole.top, width: hole.left, height: holeHeight }}
+      />
+      <div
+        className={`${dimClass} pointer-events-auto`}
+        style={{ left: hole.right, top: hole.top, width: Math.max(0, vw - hole.right), height: holeHeight }}
+      />
+
+      {/* Round off the four corners of the hole so the dim curves in under the
+          rounded ring — without these, the rectangular hole's sharp corners poke
+          out past the ring. Each is a radial gradient: transparent disc inside
+          the ring's corner radius, dim beyond it. */}
+      {[
+        { key: "tl", left: hole.left, top: hole.top, at: "bottom right" },
+        { key: "tr", left: hole.right - HOLE_RADIUS, top: hole.top, at: "bottom left" },
+        { key: "bl", left: hole.left, top: hole.bottom - HOLE_RADIUS, at: "top right" },
+        {
+          key: "br",
+          left: hole.right - HOLE_RADIUS,
+          top: hole.bottom - HOLE_RADIUS,
+          at: "top left",
+        },
+      ].map((corner) => (
+        <div
+          key={corner.key}
+          className="pointer-events-auto absolute"
+          style={{
+            left: corner.left,
+            top: corner.top,
+            width: HOLE_RADIUS,
+            height: HOLE_RADIUS,
+            background: `radial-gradient(circle at ${corner.at}, transparent 0 ${HOLE_RADIUS}px, ${DIM_COLOR} ${HOLE_RADIUS}px)`,
+          }}
+        />
+      ))}
+
+      {/* Info steps block the highlighted control so it can't be mis-clicked.
+          Action / interactive steps leave the hole open for real input. */}
+      {!step.allowInteraction ? (
+        <div
+          className="pointer-events-auto absolute"
+          style={{ left: hole.left, top: hole.top, width: holeWidth, height: holeHeight }}
+        />
+      ) : null}
+
+      {/* Highlight ring around the hole (never blocks input). */}
+      <div
+        className={`pointer-events-none absolute rounded-2xl ${transitionClass}`}
+        style={{
+          left: hole.left,
+          top: hole.top,
+          width: holeWidth,
+          height: holeHeight,
+          boxShadow:
+            "0 0 0 2px hsl(var(--accent-strong)), 0 0 0 7px hsl(var(--accent-strong)/0.22)",
+        }}
+      />
+
+      {/* Pulsing "click me" ping on action steps, so the button to click stands out. */}
+      {isAction && !reducedMotion ? (
+        <div
+          className="onboarding-pulse pointer-events-none absolute rounded-2xl"
+          style={{ left: hole.left, top: hole.top, width: holeWidth, height: holeHeight }}
+        />
+      ) : null}
+
+      {/* The control's own tooltip (computed above), in its normal position. */}
+      {tooltipNode}
+
+      {/* Positioned group: an optional "sneak peek" showcase floats above the
+          coach-mark card. The wrapper carries the position; children stack with
+          the card pinned nearest the spotlight (no position transition — it
+          repositions per step and should snap, not animate across the screen). */}
+      <div
+        className="pointer-events-none absolute flex flex-col items-center gap-3"
+        style={cardStyle}
+      >
+        {step.showcase === "layouts" ? <LayoutShowcase /> : null}
+
+        <div
+          className="pointer-events-auto squircle rounded-[24px] border border-[hsl(var(--border-muted)/0.12)] bg-[hsl(var(--surface-modal))] p-4 shadow-[0_24px_80px_-32px_hsl(var(--shadow-ambient)/0.95)]"
+          data-tour-step={step.id}
+          style={{ width: CARD_WIDTH }}
+        >
+          <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-[hsl(var(--foreground-muted))]">
+            {`${t("onboardingStepLabel", "Step")} ${stepIndex + 1} / ${stepCount}`}
+          </p>
+          <h3 className="mt-1.5 text-base font-semibold text-[hsl(var(--foreground))]">
+            {step.title}
+          </h3>
+          <p className="mt-1 text-sm leading-6 text-[hsl(var(--foreground-soft))]">{step.body}</p>
+
+          {isAction && step.hint ? (
+            <p className="mt-3 rounded-2xl bg-[hsl(var(--accent-strong))] px-3 py-2 text-sm font-medium text-[hsl(var(--foreground-on-accent))] shadow-[0_10px_24px_-18px_hsl(var(--accent-strong)/0.88)]">
+              {step.hint}
+            </p>
+          ) : null}
+
+          <div className="mt-4 flex items-center justify-between gap-2">
+            <div>
+              {stepIndex > 0 ? (
+                <Button size="sm" variant="secondary" onClick={tour.back}>
+                  <ArrowLeft size={14} aria-hidden />
+                  {t("onboardingBack", "Back")}
+                </Button>
+              ) : null}
+            </div>
+            <div className="flex items-center gap-2">
+              {isAction ? (
+                <Button size="sm" variant="secondary" onClick={tour.next}>
+                  {t("onboardingSkipStep", "Skip step")}
+                  <ArrowRight size={14} aria-hidden />
+                </Button>
+              ) : (
+                <Button size="sm" variant="primary" onClick={tour.next}>
+                  {stepIndex === stepCount - 1
+                    ? t("onboardingNextLast", "Finish")
+                    : t("onboardingNext", "Next")}
+                  <ArrowRight size={14} aria-hidden />
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/multi-panel/onboarding/onboarding-storage.ts
+++ b/src/multi-panel/onboarding/onboarding-storage.ts
@@ -1,0 +1,74 @@
+// Onboarding completion state.
+//
+// Kept in `chrome.storage.local` (NOT `ExtensionSettings`) on purpose: onboarding
+// is inherently per-install / per-device, so it must not sync across devices and
+// must not bloat settings import/export. The tour shows whenever the highest tour
+// version the user has finished is below the current `TOUR_VERSION`, which covers
+// fresh installs (no stored state) and existing users on the update that ships a
+// new tour — each exactly once. Bump `TOUR_VERSION` to re-introduce the tour after
+// a major UI redesign.
+
+export const ONBOARDING_STATE_KEY = "onboardingState";
+
+// IMPORTANT: keep this in sync with the literal mirrored in
+// background/service-worker.js (it cannot import this module).
+export const TOUR_VERSION = 1;
+
+export interface OnboardingState {
+  /** Highest tour version the user has completed or skipped. */
+  completedVersion: number;
+}
+
+export const DEFAULT_ONBOARDING_STATE: OnboardingState = { completedVersion: 0 };
+
+function hasLocalStorage(): boolean {
+  return typeof chrome !== "undefined" && Boolean(chrome.storage?.local);
+}
+
+export async function readOnboardingState(): Promise<OnboardingState> {
+  if (!hasLocalStorage()) {
+    return { ...DEFAULT_ONBOARDING_STATE };
+  }
+
+  try {
+    const result = await chrome.storage.local.get({
+      [ONBOARDING_STATE_KEY]: DEFAULT_ONBOARDING_STATE,
+    });
+    const raw = result[ONBOARDING_STATE_KEY] as Partial<OnboardingState> | undefined;
+    const completedVersion =
+      typeof raw?.completedVersion === "number" && Number.isFinite(raw.completedVersion)
+        ? raw.completedVersion
+        : 0;
+    return { completedVersion };
+  } catch {
+    return { ...DEFAULT_ONBOARDING_STATE };
+  }
+}
+
+async function writeOnboardingState(state: OnboardingState): Promise<void> {
+  if (!hasLocalStorage()) {
+    return;
+  }
+
+  try {
+    await chrome.storage.local.set({ [ONBOARDING_STATE_KEY]: state });
+  } catch {
+    // Best-effort; onboarding is non-critical state.
+  }
+}
+
+/** True when the tour should be shown for this install (not yet seen this version). */
+export async function shouldShowTour(): Promise<boolean> {
+  const state = await readOnboardingState();
+  return state.completedVersion < TOUR_VERSION;
+}
+
+/** Mark the current tour version as seen (finished or skipped). */
+export async function markTourCompleted(): Promise<void> {
+  await writeOnboardingState({ completedVersion: TOUR_VERSION });
+}
+
+/** Reset so the tour shows again — used by the in-app "Replay tutorial" action. */
+export async function resetOnboarding(): Promise<void> {
+  await writeOnboardingState({ ...DEFAULT_ONBOARDING_STATE });
+}

--- a/src/multi-panel/onboarding/onboarding-storage.ts
+++ b/src/multi-panel/onboarding/onboarding-storage.ts
@@ -10,8 +10,7 @@
 
 export const ONBOARDING_STATE_KEY = "onboardingState";
 
-// IMPORTANT: keep this in sync with the literal mirrored in
-// background/service-worker.js (it cannot import this module).
+// Bump when the tour changes enough that prior completers should see it again.
 export const TOUR_VERSION = 1;
 
 export interface OnboardingState {

--- a/src/multi-panel/onboarding/tour-steps.ts
+++ b/src/multi-panel/onboarding/tour-steps.ts
@@ -1,0 +1,222 @@
+/** Live app state the tour reads to detect when an action step is complete. */
+export interface TourContext {
+  activePanelCount: number;
+  promptQuickPickOpen: boolean;
+}
+
+/** Imperative hooks the tour can call to drive app UI during a step. */
+export interface TourActions {
+  openPromptQuickPick: () => void;
+  closePromptQuickPick: () => void;
+}
+
+export type TourPlacement = "top" | "bottom" | "auto";
+
+export interface TourStep {
+  /** Stable id; also surfaced as `data-tour-step` for E2E. */
+  id: string;
+  /** CSS selector for the highlighted element. Empty selectors are not used here
+   *  (welcome/finish are separate phases). */
+  target: string;
+  /** When the selector matches multiple nodes, which to pick. Default "first". */
+  resolve?: "first" | "last";
+  title: string;
+  body: string;
+  /** Card placement relative to the (card) anchor. "auto" picks above/below. */
+  placement?: TourPlacement;
+  /** Optional selector to position the CARD against, instead of `target`. Lets the
+   *  spotlight ring one element while the card avoids a larger surface (e.g. ring
+   *  the "Manage…" row but place the card above the whole popover). */
+  cardAnchor?: string;
+  /** Halo (px) around the target inside the spotlight hole. Default 8. */
+  spotlightPadding?: number;
+  /** "next" = advance via the card button (default). "action" = advance when the
+   *  user performs the real interaction (see `advanceWhen`). */
+  advance?: "next" | "action";
+  /** Let real pointer events reach the highlighted control (required for action
+   *  steps and for hover-to-expand targets like the panel capsule). */
+  allowInteraction?: boolean;
+  /** Call-to-action shown on action steps in place of a Next button. */
+  hint?: string;
+  /** For action steps: return true once the interaction has happened. `baseline`
+   *  is a snapshot of the context taken when the step became active. */
+  advanceWhen?: (ctx: TourContext, baseline: TourContext) => boolean;
+  /** Focus a button inside the highlighted panel capsule so `group-focus-within`
+   *  holds it open — reveals the 5 controls without requiring a hover. */
+  expandCapsule?: boolean;
+  /** Keep the app's real hover/focus tooltips working during this step instead
+   *  of suppressing them — used when the highlighted area has several controls
+   *  the user should hover to identify (e.g. the panel-control capsule). */
+  nativeTooltips?: boolean;
+  /** Float a small visual "sneak peek" panel above the coach-mark card. Only
+   *  "layouts" is supported: mini previews (1×3, 2×2, 3×3) so the user gets a
+   *  feel for the layout picker without opening it. */
+  showcase?: "layouts";
+  /** Side effect when the step becomes active (e.g. ensure popover closed). */
+  onEnter?: (actions: TourActions) => void;
+  /** Cleanup when leaving the step in any direction (e.g. close the popover). */
+  onLeave?: (actions: TourActions) => void;
+}
+
+type TranslateFn = (
+  key: string,
+  fallback: string,
+  substitutions?: string | string[] | null,
+) => string;
+
+/**
+ * The ordered spotlight steps. Welcome/Finish are rendered as separate modal
+ * phases by the view, so they are not part of this array (keeps "Step n of N"
+ * meaningful). Targets anchor to MAIN-document elements only — never the
+ * cross-origin provider iframes.
+ */
+export function buildTourSteps(t: TranslateFn): TourStep[] {
+  return [
+    {
+      id: "composer-input",
+      target: '[data-tour="composer-input"]',
+      title: t("onboardingInputTitle", "Type your prompt here"),
+      body: t(
+        "onboardingInputBody",
+        "This is your shared composer. Whatever you type here can be sent to every AI panel at once.",
+      ),
+      placement: "top",
+    },
+    {
+      id: "composer-bar",
+      target: '[data-tour="composer-bar"]',
+      title: t("onboardingBarTitle", "Move the composer"),
+      body: t(
+        "onboardingBarBody",
+        "Drag this bar to move the composer anywhere — go ahead and try it now, or just continue. Double-click it to snap back to the default spot.",
+      ),
+      placement: "top",
+      spotlightPadding: 4,
+      // Optional hands-on moment: leave the hole open so the user can actually
+      // grab and drag the bar. It stays an info step (Next advances), so trying
+      // the drag is encouraged but never required.
+      allowInteraction: true,
+    },
+    {
+      id: "send-all",
+      target: '[data-tour="send-all"]',
+      title: t("onboardingSendTitle", "Ask everywhere at once"),
+      body: t(
+        "onboardingSendBody",
+        "Type a prompt once and send it to every AI panel together. Watch the lines animate as it dispatches.",
+      ),
+    },
+    {
+      id: "layout",
+      target: '[data-tour="layout"]',
+      title: t("onboardingLayoutTitle", "Choose your layout"),
+      body: t(
+        "onboardingLayoutBody",
+        "Rearrange the panels into split-screen grids — from a single focus pane up to a 4×4 wall.",
+      ),
+      showcase: "layouts",
+    },
+    {
+      id: "prompt-library",
+      target: '[data-tour="prompt-library"]',
+      title: t("onboardingPromptTitle", "Reuse your best prompts"),
+      body: t(
+        "onboardingPromptBody",
+        "Keep a library of prompts with fill-in blanks. Click to open your prompt menu.",
+      ),
+      advance: "action",
+      allowInteraction: true,
+      hint: t("onboardingPromptHint", "Click the prompt button to open the menu"),
+      advanceWhen: (ctx) => ctx.promptQuickPickOpen,
+      // Start from a known-closed state so the click->open transition is clean.
+      onEnter: (actions) => actions.closePromptQuickPick(),
+    },
+    {
+      id: "manage-prompts",
+      target: '[data-tour="manage-prompts"]',
+      title: t("onboardingManageTitle", "Manage your prompt library"),
+      body: t(
+        "onboardingManageBody",
+        "Click this to manage your custom prompts — create, edit, favorite, and import or export them.",
+      ),
+      allowInteraction: true,
+      spotlightPadding: 10,
+      // Ring the "Manage…" row, but float the card above the whole popover so it
+      // never covers the search bar (a fresh user's favorites list is empty, so
+      // the popover is short and the card sits just above it).
+      cardAnchor: "[data-onboarding-popover]",
+      placement: "top",
+      // Closed when the user moves on so it doesn't linger over the next step.
+      onLeave: (actions) => actions.closePromptQuickPick(),
+    },
+    {
+      id: "scroll-sync",
+      target: '[data-tour="scroll-sync"]',
+      title: t("onboardingScrollTitle", "Scroll in sync"),
+      body: t(
+        "onboardingScrollBody",
+        "Keep every panel scrolling together so you can compare answers side by side. Toggle it on or off whenever you like — it's on by default.",
+      ),
+    },
+    {
+      id: "add-pane",
+      target: '[data-tour="add-pane"]',
+      title: t("onboardingAddTitle", "Add another AI chat panel"),
+      body: t(
+        "onboardingAddBody",
+        "Bring in one more model. Click + and watch the layout grow to fit the new panel.",
+      ),
+      advance: "action",
+      allowInteraction: true,
+      hint: t("onboardingAddHint", "Click + to add a panel"),
+      advanceWhen: (ctx, baseline) => ctx.activePanelCount > baseline.activePanelCount,
+    },
+    {
+      id: "panel-controls",
+      target: "[data-panel-control-capsule]",
+      resolve: "last",
+      title: t("onboardingControlsTitle", "Per-panel controls"),
+      body: t(
+        "onboardingControlsBody",
+        "Hover over the top panel control bar to expand it and show the per-panel controls. Each panel has its own controls: switch provider, drag to reorder, focus, start a new chat, and close — hover any button to see what it does.",
+      ),
+      allowInteraction: true,
+      expandCapsule: true,
+      // Let the real tooltips appear so the user can hover each control to learn it.
+      nativeTooltips: true,
+      // The expanded capsule is a tight 44px row; a small halo hugs it. A large
+      // pad reads as empty space because the capsule sits near the panel top, so
+      // the top pad clamps to the viewport edge and the hole goes bottom-heavy.
+      spotlightPadding: 10,
+      placement: "bottom",
+    },
+    {
+      // `expandCapsule` holds the bar open (so all 5 buttons show), and the
+      // spotlight rings the ✕ specifically.
+      id: "close-pane",
+      target: '[data-tour="panel-close"]',
+      resolve: "last",
+      title: t("onboardingCloseTitle", "Close a panel"),
+      body: t(
+        "onboardingCloseBody",
+        "Click ✕ to close this panel and return to your previous layout.",
+      ),
+      advance: "action",
+      allowInteraction: true,
+      expandCapsule: true,
+      spotlightPadding: 8,
+      placement: "bottom",
+      hint: t("onboardingCloseHint", "Click ✕ to close the panel"),
+      advanceWhen: (ctx, baseline) => ctx.activePanelCount < baseline.activePanelCount,
+    },
+    {
+      id: "settings",
+      target: '[data-tour="settings"]',
+      title: t("onboardingSettingsTitle", "Make it yours"),
+      body: t(
+        "onboardingSettingsBody",
+        "Pick providers, theme, and keyboard shortcuts here — and replay this tour anytime.",
+      ),
+    },
+  ];
+}

--- a/src/multi-panel/onboarding/useOnboardingTour.ts
+++ b/src/multi-panel/onboarding/useOnboardingTour.ts
@@ -1,0 +1,491 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useTranslation } from "@/shared/contexts/I18nContext";
+import {
+  buildTourSteps,
+  type TourActions,
+  type TourContext,
+  type TourStep,
+} from "@/multi-panel/onboarding/tour-steps";
+import {
+  markTourCompleted,
+  resetOnboarding,
+  shouldShowTour,
+} from "@/multi-panel/onboarding/onboarding-storage";
+
+export type TourPhase = "idle" | "welcome" | "step" | "finish";
+
+export interface OnboardingTourController {
+  phase: TourPhase;
+  step: TourStep | null;
+  stepIndex: number;
+  stepCount: number;
+  targetRect: DOMRect | null;
+  /** Rect of the step's `cardAnchor` element, if any (for card positioning). */
+  cardRect: DOMRect | null;
+  /** The highlighted control's own tooltip, surfaced in its normal position. */
+  activeTooltip: { text: string; placement: "top" | "bottom" | null } | null;
+  reducedMotion: boolean;
+  /** Replay: show the tour from the start regardless of stored version. */
+  start: () => void;
+  /** Welcome → first step, or step → next step (last step → finish). */
+  next: () => void;
+  /** Step → previous step (first step → welcome). */
+  back: () => void;
+  /** End the tour now (skip / done). Marks the current version completed. */
+  skip: () => void;
+}
+
+interface UseOnboardingTourOptions {
+  ready: boolean;
+  context: TourContext;
+  actions: TourActions;
+}
+
+// How long to wait for a step's target to appear before skipping it (frames).
+const MAX_MISSING_FRAMES = 150;
+
+// How long the finish confetti celebration plays before the tour closes itself.
+const FINISH_CELEBRATION_MS = 2300;
+
+function resolveTarget(step: TourStep | null): HTMLElement | null {
+  if (!step?.target) {
+    return null;
+  }
+  const matches = document.querySelectorAll<HTMLElement>(step.target);
+  if (matches.length === 0) {
+    return null;
+  }
+  return step.resolve === "last" ? matches[matches.length - 1] : matches[0];
+}
+
+// Whether a step can be entered now — i.e. its target currently resolves.
+function isResolvable(step: TourStep): boolean {
+  return resolveTarget(step) !== null;
+}
+
+// Arrow-key navigation must not hijack ACTIVE text editing — but app fields
+// (the composer, the prompt-search box) auto-focus during the tour while still
+// empty, and there arrows do nothing useful, so let them drive the tour. We only
+// defer to a text field once it actually holds text (then caret movement
+// matters); selects and contenteditable always win.
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    return target.value.length > 0;
+  }
+  return target.tagName === "SELECT" || target.isContentEditable;
+}
+
+function rectsEqual(a: DOMRect | null, b: DOMRect | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.left === b.left && a.top === b.top && a.width === b.width && a.height === b.height
+  );
+}
+
+export function useOnboardingTour({
+  ready,
+  context,
+  actions,
+}: UseOnboardingTourOptions): OnboardingTourController {
+  const { t } = useTranslation();
+  const steps = useMemo(() => buildTourSteps(t), [t]);
+
+  const [phase, setPhase] = useState<TourPhase>("idle");
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const [cardRect, setCardRect] = useState<DOMRect | null>(null);
+  const [activeTooltip, setActiveTooltip] = useState<
+    { text: string; placement: "top" | "bottom" | null } | null
+  >(null);
+
+  const reducedMotion = useMemo(
+    () => window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+    [],
+  );
+
+  // Refs so effects/handlers always see the latest values without re-subscribing.
+  const contextRef = useRef(context);
+  contextRef.current = context;
+  const actionsRef = useRef(actions);
+  actionsRef.current = actions;
+  const stepsRef = useRef(steps);
+  stepsRef.current = steps;
+  const phaseRef = useRef(phase);
+  phaseRef.current = phase;
+  const indexRef = useRef(currentIndex);
+  indexRef.current = currentIndex;
+
+  const baselineRef = useRef<TourContext>(context);
+  const armedRef = useRef(false);
+  const autoStartedRef = useRef(false);
+  const activeElRef = useRef<HTMLElement | null>(null);
+  const lastRectRef = useRef<DOMRect | null>(null);
+  const lastCardRectRef = useRef<DOMRect | null>(null);
+  const lastTooltipKeyRef = useRef<string | null>(null);
+
+  const { activePanelCount, promptQuickPickOpen } = context;
+
+  const setActiveElement = useCallback((el: HTMLElement | null) => {
+    if (activeElRef.current === el) {
+      return;
+    }
+    activeElRef.current?.removeAttribute("data-tour-active");
+    el?.setAttribute("data-tour-active", "true");
+    activeElRef.current = el;
+  }, []);
+
+  const clearHighlight = useCallback(() => {
+    setActiveElement(null);
+    lastRectRef.current = null;
+    setTargetRect(null);
+    lastCardRectRef.current = null;
+    setCardRect(null);
+    lastTooltipKeyRef.current = null;
+    setActiveTooltip(null);
+  }, [setActiveElement]);
+
+  const endTour = useCallback(() => {
+    void markTourCompleted();
+    clearHighlight();
+    setPhase("idle");
+  }, [clearHighlight]);
+
+  // Forward search for the next index whose target currently resolves (so a
+  // missing/removed control never traps the tour). Returns -1 if none remain.
+  const findForward = useCallback((from: number): number => {
+    const list = stepsRef.current;
+    let i = from;
+    while (i < list.length && !isResolvable(list[i])) {
+      i += 1;
+    }
+    return i < list.length ? i : -1;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const findBackward = useCallback((from: number): number => {
+    const list = stepsRef.current;
+    let i = from;
+    while (i >= 0 && !isResolvable(list[i])) {
+      i -= 1;
+    }
+    return i;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const leaveCurrentStep = useCallback(() => {
+    if (phaseRef.current === "step") {
+      stepsRef.current[indexRef.current]?.onLeave?.(actionsRef.current);
+    }
+  }, []);
+
+  const next = useCallback(() => {
+    const ph = phaseRef.current;
+    if (ph === "welcome") {
+      const first = findForward(0);
+      if (first === -1) {
+        endTour();
+        return;
+      }
+      setCurrentIndex(first);
+      setPhase("step");
+      return;
+    }
+    if (ph === "finish") {
+      endTour();
+      return;
+    }
+    if (ph !== "step") {
+      return;
+    }
+    leaveCurrentStep();
+    const target = findForward(indexRef.current + 1);
+    if (target === -1) {
+      clearHighlight();
+      setPhase("finish");
+      return;
+    }
+    setCurrentIndex(target);
+  }, [clearHighlight, endTour, findForward, leaveCurrentStep]);
+
+  const back = useCallback(() => {
+    if (phaseRef.current !== "step") {
+      return;
+    }
+    leaveCurrentStep();
+    const target = findBackward(indexRef.current - 1);
+    if (target < 0) {
+      clearHighlight();
+      setPhase("welcome");
+      return;
+    }
+    setCurrentIndex(target);
+  }, [clearHighlight, findBackward, leaveCurrentStep]);
+
+  const skip = useCallback(() => {
+    leaveCurrentStep();
+    endTour();
+  }, [endTour, leaveCurrentStep]);
+
+  const start = useCallback(() => {
+    void resetOnboarding();
+    autoStartedRef.current = true;
+    leaveCurrentStep();
+    clearHighlight();
+    setCurrentIndex(0);
+    setPhase("welcome");
+  }, [clearHighlight, leaveCurrentStep]);
+
+  // Auto-start once the app is ready, if this tour version hasn't been seen.
+  useEffect(() => {
+    if (!ready || autoStartedRef.current || phaseRef.current !== "idle") {
+      return;
+    }
+    autoStartedRef.current = true;
+    void shouldShowTour().then((show) => {
+      if (show && phaseRef.current === "idle") {
+        setPhase("welcome");
+      }
+    });
+  }, [ready]);
+
+  // Step entry: snapshot baseline, run onEnter, reset the action arming.
+  useEffect(() => {
+    if (phase !== "step") {
+      return;
+    }
+    const step = steps[currentIndex];
+    if (!step) {
+      return;
+    }
+    baselineRef.current = contextRef.current;
+    armedRef.current = false;
+    step.onEnter?.(actionsRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, currentIndex]);
+
+  // Measure loop: keep `targetRect` in sync with the live element via rAF. This
+  // covers resize, scroll, and hover-driven growth (the capsule expands) without
+  // separate listeners, and skips a step whose target never appears.
+  useEffect(() => {
+    if (phase !== "step") {
+      clearHighlight();
+      return;
+    }
+    const step = steps[currentIndex];
+    if (!step) {
+      return;
+    }
+
+    let frame = 0;
+    let missingFrames = 0;
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled) {
+        return;
+      }
+      const el = resolveTarget(step);
+      if (el) {
+        missingFrames = 0;
+        setActiveElement(el);
+
+        // Surface the control's own tooltip in its normal position (the app's
+        // TooltipProvider is suppressed during the tour — see the body flag below).
+        if (el.dataset.tooltip) {
+          const placement =
+            el.dataset.tooltipPlacement === "top"
+              ? "top"
+              : el.dataset.tooltipPlacement === "bottom"
+                ? "bottom"
+                : null;
+          const key = `${el.dataset.tooltip}|${placement ?? ""}`;
+          if (lastTooltipKeyRef.current !== key) {
+            lastTooltipKeyRef.current = key;
+            setActiveTooltip({ text: el.dataset.tooltip, placement });
+          }
+        } else if (lastTooltipKeyRef.current !== null) {
+          lastTooltipKeyRef.current = null;
+          setActiveTooltip(null);
+        }
+
+        // Hold the panel capsule open by keeping focus inside it (the controls
+        // expand on `group-focus-within`). Re-focus only if focus has escaped so
+        // we don't fight the user.
+        if (step.expandCapsule) {
+          const group = el.closest<HTMLElement>(".group\\/panel-controls") ?? el;
+          if (!group.matches(":focus-within")) {
+            const focusEl = el.matches("button")
+              ? el
+              : el.querySelector<HTMLElement>("button");
+            focusEl?.focus({ preventScroll: true });
+          }
+        }
+        const rect = el.getBoundingClientRect();
+        if (!rectsEqual(rect, lastRectRef.current)) {
+          lastRectRef.current = rect;
+          setTargetRect(rect);
+        }
+
+        // Measure the (optional) card anchor every frame too, so the card can
+        // float above a larger surface (e.g. the prompt popover) reliably.
+        const anchorEl = step.cardAnchor
+          ? document.querySelector<HTMLElement>(step.cardAnchor)
+          : null;
+        const anchorRect = anchorEl?.getBoundingClientRect() ?? null;
+        if (!rectsEqual(anchorRect, lastCardRectRef.current)) {
+          lastCardRectRef.current = anchorRect;
+          setCardRect(anchorRect);
+        }
+      } else {
+        missingFrames += 1;
+        if (missingFrames > MAX_MISSING_FRAMES) {
+          cancelled = true;
+          const fwd = findForward(currentIndex + 1);
+          clearHighlight();
+          if (fwd === -1) {
+            setPhase("finish");
+          } else {
+            setCurrentIndex(fwd);
+          }
+          return;
+        }
+      }
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, currentIndex, clearHighlight, findForward, setActiveElement]);
+
+  // Action-step auto-advance. Arm only after the predicate is observed false at
+  // least once, so a condition that's already true on entry (e.g. returning via
+  // Back with the popover open) doesn't instantly advance.
+  useEffect(() => {
+    if (phase !== "step") {
+      return;
+    }
+    const step = steps[currentIndex];
+    if (step?.advance !== "action" || !step.advanceWhen) {
+      return;
+    }
+    const satisfied = step.advanceWhen(contextRef.current, baselineRef.current);
+    if (!armedRef.current) {
+      if (!satisfied) {
+        armedRef.current = true;
+      }
+      return;
+    }
+    if (satisfied) {
+      next();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, currentIndex, activePanelCount, promptQuickPickOpen, next]);
+
+  // Keep-open guard: the quick-pick popover self-closes on stray outside clicks /
+  // blur; while highlighting its "Manage…" row, re-open it so the target stays.
+  useEffect(() => {
+    if (phase !== "step") {
+      return;
+    }
+    if (steps[currentIndex]?.id !== "manage-prompts") {
+      return;
+    }
+    if (!promptQuickPickOpen) {
+      actionsRef.current.openPromptQuickPick();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase, currentIndex, promptQuickPickOpen]);
+
+  // Keyboard navigation while the tour is active. Capture phase so it beats the
+  // composer's stop-generation and the popover's own handlers. Escape always
+  // exits; Left/Right step back/forward — but never while the user is typing in
+  // an input, so text editing on interactive steps still works.
+  useEffect(() => {
+    if (phase === "idle") {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        skip();
+        return;
+      }
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") {
+        return;
+      }
+      if (event.altKey || event.metaKey || event.ctrlKey || isEditableTarget(event.target)) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "ArrowRight") {
+        next();
+      } else {
+        back();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [phase, skip, next, back]);
+
+  // Flag the body while the tour is active so the app's hover/focus tooltips stay
+  // out of the way — the tour renders the highlighted control's tooltip itself.
+  // Steps that opt into `nativeTooltips` lift the flag so the user can hover the
+  // real controls (e.g. the panel-control capsule) and read their tooltips.
+  useEffect(() => {
+    const suppress = phase !== "idle" && !steps[currentIndex]?.nativeTooltips;
+    if (suppress) {
+      document.body.dataset.onboardingTour = "active";
+    } else {
+      delete document.body.dataset.onboardingTour;
+    }
+    return () => {
+      delete document.body.dataset.onboardingTour;
+    };
+  }, [phase, currentIndex, steps]);
+
+  // Finish: record completion, let the confetti celebration play briefly, then
+  // close the tour on its own. There's no dismiss button — it's a flourish, not
+  // a modal — so completion is persisted immediately on entry.
+  useEffect(() => {
+    if (phase !== "finish") {
+      return;
+    }
+    void markTourCompleted();
+    const timer = window.setTimeout(() => {
+      clearHighlight();
+      setPhase("idle");
+    }, FINISH_CELEBRATION_MS);
+    return () => window.clearTimeout(timer);
+  }, [phase, clearHighlight]);
+
+  // Clean up the highlight attribute if the component unmounts mid-tour.
+  useEffect(() => () => setActiveElement(null), [setActiveElement]);
+
+  const step = phase === "step" ? steps[currentIndex] ?? null : null;
+
+  return {
+    phase,
+    step,
+    stepIndex: currentIndex,
+    stepCount: steps.length,
+    targetRect,
+    cardRect,
+    activeTooltip,
+    reducedMotion,
+    start,
+    next,
+    back,
+    skip,
+  };
+}

--- a/src/multi-panel/onboarding/useOnboardingTour.ts
+++ b/src/multi-panel/onboarding/useOnboardingTour.ts
@@ -345,6 +345,9 @@ export function useOnboardingTour({
         missingFrames += 1;
         if (missingFrames > MAX_MISSING_FRAMES) {
           cancelled = true;
+          // Run the abandoned step's onLeave (e.g. close the prompt popover),
+          // just as next()/back() do — auto-skipping must not drop cleanup.
+          leaveCurrentStep();
           const fwd = findForward(currentIndex + 1);
           clearHighlight();
           if (fwd === -1) {
@@ -364,7 +367,7 @@ export function useOnboardingTour({
       cancelAnimationFrame(frame);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase, currentIndex, clearHighlight, findForward, setActiveElement]);
+  }, [phase, currentIndex, clearHighlight, findForward, leaveCurrentStep, setActiveElement]);
 
   // Action-step auto-advance. Arm only after the predicate is observed false at
   // least once, so a condition that's already true on entry (e.g. returning via

--- a/src/shared/components/TooltipProvider.tsx
+++ b/src/shared/components/TooltipProvider.tsx
@@ -79,7 +79,13 @@ export function TooltipProvider() {
       }, HOVER_DELAY_MS);
     };
 
+    const isSuppressed = () => Boolean(document.body.dataset.onboardingTour);
+
     const handlePointerOver = (event: PointerEvent) => {
+      if (isSuppressed()) {
+        return;
+      }
+
       const target = readTooltipTarget(event.target);
 
       if (!target) {
@@ -115,6 +121,9 @@ export function TooltipProvider() {
     };
 
     const handleFocusIn = (event: FocusEvent) => {
+      if (isSuppressed()) {
+        return;
+      }
       showTooltip(readTooltipTarget(event.target));
     };
 

--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -432,6 +432,84 @@ html[data-theme="light"] .brand-mark__shape {
   }
 }
 
+/* Pulsing "click me" ping used on onboarding action steps. */
+.onboarding-pulse {
+  animation: onboarding-pulse 1.5s ease-out infinite;
+}
+
+@keyframes onboarding-pulse {
+  0% {
+    box-shadow: 0 0 0 0 hsl(var(--accent-strong) / 0.5);
+  }
+
+  70% {
+    box-shadow: 0 0 0 16px hsl(var(--accent-strong) / 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 hsl(var(--accent-strong) / 0);
+  }
+}
+
+/* Confetti celebration shown when the onboarding tour finishes. */
+.onboarding-confetti-piece {
+  position: absolute;
+  top: 0;
+  will-change: transform, opacity;
+  animation: onboarding-confetti-fall var(--confetti-duration, 2s)
+    cubic-bezier(0.18, 0.6, 0.4, 1) var(--confetti-delay, 0s) forwards;
+}
+
+@keyframes onboarding-confetti-fall {
+  0% {
+    transform: translate3d(0, -12vh, 0) rotateZ(0deg);
+    opacity: 0;
+  }
+
+  8% {
+    opacity: 1;
+  }
+
+  85% {
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate3d(var(--confetti-drift, 0), 112vh, 0)
+      rotateZ(var(--confetti-spin, 540deg));
+    opacity: 0;
+  }
+}
+
+.onboarding-celebrate {
+  animation: onboarding-celebrate-pop 2.3s ease-out forwards;
+}
+
+@keyframes onboarding-celebrate-pop {
+  0% {
+    transform: translate(-50%, -50%) scale(0.6);
+    opacity: 0;
+  }
+
+  18% {
+    transform: translate(-50%, -50%) scale(1.08);
+    opacity: 1;
+  }
+
+  32% {
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  82% {
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 0;
+  }
+}
+
 @keyframes composer-connector-dash {
   to {
     stroke-dashoffset: -90;

--- a/tests/e2e/_fixtures.ts
+++ b/tests/e2e/_fixtures.ts
@@ -21,8 +21,13 @@ type ExtensionFixtures = {
   extensionId: string;
   /**
    * Opens the multi-panel page with provider routes installed before navigation.
+   * The onboarding tour is seeded as already-completed by default so it doesn't
+   * overlay the workspace; pass `onboarding: true` to let it auto-start.
    */
-  openMultiPanel: (options?: { stubProviders?: boolean }) => Promise<Page>;
+  openMultiPanel: (options?: {
+    stubProviders?: boolean;
+    onboarding?: boolean;
+  }) => Promise<Page>;
 };
 
 /**
@@ -70,6 +75,22 @@ export const test = base.extend<ExtensionFixtures>({
       const stubProviders = options?.stubProviders ?? true;
       if (stubProviders) {
         await stubProviderRequests(page);
+      }
+      // The tour auto-starts on a fresh install (empty storage) and would overlay
+      // the workspace, blocking unrelated specs. Seed it as completed unless the
+      // spec explicitly exercises the tour. The init script runs at document
+      // start, before the app reads its onboarding state.
+      if (!options?.onboarding) {
+        await page.addInitScript(() => {
+          try {
+            if (typeof chrome !== "undefined" && chrome.storage?.local) {
+              // A version past any TOUR_VERSION, so shouldShowTour() stays false.
+              void chrome.storage.local.set({ onboardingState: { completedVersion: 9999 } });
+            }
+          } catch {
+            // Provider iframes have no chrome.storage — ignore.
+          }
+        });
       }
       await page.goto(`chrome-extension://${extensionId}/multi-panel/index.html`);
       return page;

--- a/tests/e2e/fixtures/onboarding-tour.spec.ts
+++ b/tests/e2e/fixtures/onboarding-tour.spec.ts
@@ -1,0 +1,186 @@
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "../_fixtures";
+
+// Always record a video of the full run + a screenshot per step. Artifacts land
+// under tests/e2e/.artifacts (Playwright outputDir) for visual review.
+test.use({ video: "on" });
+
+const SHOTS_DIR = "tests/e2e/.artifacts/onboarding";
+const TOUR_VERSION = 1;
+
+async function shot(page: Page, name: string) {
+  await page.screenshot({ path: `${SHOTS_DIR}/${name}.png` });
+}
+
+async function currentLayout(page: Page): Promise<string | undefined> {
+  return page.evaluate(async () => {
+    const result = await chrome.storage.sync.get("currentLayout");
+    return result.currentLayout as string | undefined;
+  });
+}
+
+async function completedVersion(page: Page): Promise<number | undefined> {
+  return page.evaluate(async () => {
+    const result = await chrome.storage.local.get("onboardingState");
+    return (result.onboardingState as { completedVersion?: number } | undefined)?.completedVersion;
+  });
+}
+
+function card(page: Page, stepId: string) {
+  return page.locator(`[data-tour-step="${stepId}"]`);
+}
+
+test.describe("onboarding tour", () => {
+  test("walks the full interactive tour on first open", async ({ openMultiPanel }) => {
+    const page = await openMultiPanel();
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+
+    // --- Welcome ---
+    const startButton = page.getByRole("button", { name: "Start tour" });
+    await expect(startButton).toBeVisible({ timeout: 10_000 });
+    await shot(page, "01-welcome");
+    await startButton.click();
+
+    // --- Info step: Composer input ---
+    await expect(card(page, "composer-input")).toBeVisible();
+    await shot(page, "02-composer-input");
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // --- Info step: Composer drag bar (now interactive — optional drag) ---
+    await expect(card(page, "composer-bar")).toBeVisible();
+    await shot(page, "03-composer-bar");
+    // The bar is draggable during this step. Grab an empty spot (left of the
+    // toolbar buttons) and drag it up; the composer should actually move.
+    const bar = page.locator('[data-tour="composer-bar"]');
+    const beforeBox = (await bar.boundingBox())!;
+    const grabX = beforeBox.x + 40;
+    const grabY = beforeBox.y + beforeBox.height / 2;
+    await page.mouse.move(grabX, grabY);
+    await page.mouse.down();
+    await page.mouse.move(grabX, grabY - 120, { steps: 12 });
+    await page.mouse.up();
+    const draggedBox = (await bar.boundingBox())!;
+    expect(draggedBox.y).toBeLessThan(beforeBox.y - 20);
+    await shot(page, "03b-composer-bar-dragged");
+    // Double-click snaps it back to the default spot (per the step copy).
+    await page.mouse.dblclick(grabX, draggedBox.y + draggedBox.height / 2);
+    await expect
+      .poll(async () => (await bar.boundingBox())!.y)
+      .toBeGreaterThan(draggedBox.y + 20);
+    // Optional: Next still advances regardless of whether the user dragged.
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // --- Info step: Send all ---
+    await expect(card(page, "send-all")).toBeVisible();
+    await expect(page.locator('[data-tour="send-all"][data-tour-active="true"]')).toBeVisible();
+    await shot(page, "04-send-all");
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // --- Info step: Layout (with the floating "sneak peek" showcase) ---
+    await expect(card(page, "layout")).toBeVisible();
+    const layoutShowcase = page.locator('[data-tour-showcase="layouts"]');
+    await expect(layoutShowcase).toBeVisible();
+    for (const label of ["1×3", "2×2", "3×3"]) {
+      await expect(layoutShowcase.getByText(label, { exact: true })).toBeVisible();
+    }
+    await shot(page, "05-layout");
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // --- Action step: Prompt library (click opens the quick-pick popover) ---
+    await expect(card(page, "prompt-library")).toBeVisible();
+    await shot(page, "06-prompt-library");
+    await page.locator('[data-tour="prompt-library"]').click({ force: true });
+
+    // --- Info step: Manage prompts (highlighted inside the popover) ---
+    await expect(card(page, "manage-prompts")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-tour="manage-prompts"]')).toBeVisible();
+    await shot(page, "07-manage-prompts");
+    // Keep-open guard: a click on the dimmer must not collapse the popover.
+    await page.mouse.click(8, Math.round(page.viewportSize()!.height / 2));
+    await expect(page.locator('[data-tour="manage-prompts"]')).toBeVisible();
+    // Arrow keys must drive the tour even with the popover's (empty) search box
+    // focused — pressing Right advances past this step and closes the popover.
+    await page.getByPlaceholder("Search favorites and recent prompts").focus();
+    await page.keyboard.press("ArrowRight");
+    await expect(page.locator('[data-tour="manage-prompts"]')).toHaveCount(0);
+
+    // --- Info step: Scroll sync ---
+    await expect(card(page, "scroll-sync")).toBeVisible();
+    await shot(page, "08-scroll-sync");
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // --- Action step: Add a pane (1x3 -> 1x4) ---
+    await expect(card(page, "add-pane")).toBeVisible();
+    await shot(page, "09-add-pane");
+    const beforeCapsules = await page.locator("[data-panel-control-capsule]").count();
+    await page.locator('[data-tour="add-pane"]').click({ force: true });
+    await expect.poll(() => currentLayout(page), { timeout: 10_000 }).toBe("1x4");
+    await expect(page.locator("[data-panel-control-capsule]")).toHaveCount(beforeCapsules + 1);
+
+    // --- Info step: Panel controls (hover reveals each control's tooltip) ---
+    await expect(card(page, "panel-controls")).toBeVisible({ timeout: 10_000 });
+    const lastClose = page.locator('[data-tour="panel-close"]').last();
+    await expect(lastClose).toBeVisible({ timeout: 10_000 });
+    // Real tooltips work on this step: hover a control and its label appears.
+    await lastClose.hover();
+    const controlTip = page.locator(".app-tooltip");
+    await expect(controlTip).toBeVisible({ timeout: 5_000 });
+    await expect(controlTip).toContainText("Close this panel");
+    await shot(page, "10-panel-controls");
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // --- Action step: Close the pane (1x4 -> 1x3) ---
+    await expect(card(page, "close-pane")).toBeVisible();
+    const closeButton = page.locator('[data-tour="panel-close"]').last();
+    await expect(closeButton).toBeVisible({ timeout: 10_000 });
+    await shot(page, "11-close-pane");
+    await closeButton.click({ force: true });
+    await expect.poll(() => currentLayout(page), { timeout: 10_000 }).toBe("1x3");
+
+    // --- Info step: Settings ---
+    await expect(card(page, "settings")).toBeVisible({ timeout: 10_000 });
+    await shot(page, "12-settings");
+    await page.getByRole("button", { name: "Finish", exact: true }).click();
+
+    // --- Finish: confetti celebration, no modal, auto-dismisses ---
+    const finish = page.locator('[data-onboarding-phase="finish"]');
+    await expect(finish).toBeVisible();
+    await expect(page.getByText("You're all set!")).toBeVisible();
+    // There is no "Get started" button — the celebration replaces the modal.
+    await expect(page.getByRole("button", { name: "Get started" })).toHaveCount(0);
+    await page.waitForTimeout(500); // let the confetti spread for the screenshot
+    await shot(page, "13-finish");
+
+    // Completion is persisted immediately on entering the celebration.
+    await expect.poll(() => completedVersion(page)).toBe(TOUR_VERSION);
+    // It closes itself with no further interaction.
+    await expect(finish).toHaveCount(0, { timeout: 5_000 });
+
+    // Does not re-fire on reload.
+    await page.reload();
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Start tour" })).toHaveCount(0);
+  });
+
+  test("can be replayed from Settings", async ({ openMultiPanel }) => {
+    const page = await openMultiPanel();
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+
+    // Dismiss the first-run tour.
+    const startButton = page.getByRole("button", { name: "Start tour" });
+    await expect(startButton).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Skip", exact: true }).click();
+    await expect(startButton).toHaveCount(0);
+
+    // Open Settings → About tab → Replay tutorial.
+    await page.locator('[data-tour="settings"]').click();
+    await page.getByRole("button", { name: "About", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Onboarding tour" })).toBeVisible();
+    await shot(page, "14-about-replay");
+    await page.getByRole("button", { name: "Replay tutorial" }).click();
+
+    await expect(page.getByRole("button", { name: "Start tour" })).toBeVisible({ timeout: 10_000 });
+    await shot(page, "15-replay-welcome");
+  });
+});

--- a/tests/e2e/fixtures/onboarding-tour.spec.ts
+++ b/tests/e2e/fixtures/onboarding-tour.spec.ts
@@ -33,7 +33,7 @@ function card(page: Page, stepId: string) {
 
 test.describe("onboarding tour", () => {
   test("walks the full interactive tour on first open", async ({ openMultiPanel }) => {
-    const page = await openMultiPanel();
+    const page = await openMultiPanel({ onboarding: true });
     await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
 
     // --- Welcome ---
@@ -164,7 +164,7 @@ test.describe("onboarding tour", () => {
   });
 
   test("can be replayed from Settings", async ({ openMultiPanel }) => {
-    const page = await openMultiPanel();
+    const page = await openMultiPanel({ onboarding: true });
     await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
 
     // Dismiss the first-run tour.

--- a/tests/multi-panel/onboarding/OnboardingTour.test.tsx
+++ b/tests/multi-panel/onboarding/OnboardingTour.test.tsx
@@ -1,0 +1,171 @@
+import { screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "../../helpers/render";
+import { OnboardingTour } from "@/multi-panel/onboarding/OnboardingTour";
+import type { TourStep } from "@/multi-panel/onboarding/tour-steps";
+import type { OnboardingTourController } from "@/multi-panel/onboarding/useOnboardingTour";
+
+function fakeRect(overrides: Partial<DOMRect> = {}): DOMRect {
+  return {
+    x: 100,
+    y: 100,
+    left: 100,
+    top: 100,
+    right: 220,
+    bottom: 150,
+    width: 120,
+    height: 50,
+    ...overrides,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function makeController(
+  overrides: Partial<OnboardingTourController> = {},
+): OnboardingTourController {
+  return {
+    phase: "idle",
+    step: null,
+    stepIndex: 0,
+    stepCount: 11,
+    targetRect: null,
+    cardRect: null,
+    activeTooltip: null,
+    reducedMotion: false,
+    start: vi.fn(),
+    next: vi.fn(),
+    back: vi.fn(),
+    skip: vi.fn(),
+    ...overrides,
+  };
+}
+
+const layoutStep: TourStep = {
+  id: "layout",
+  target: '[data-tour="layout"]',
+  title: "Choose your layout",
+  body: "Rearrange the panels into split-screen grids.",
+  showcase: "layouts",
+};
+
+const actionStep: TourStep = {
+  id: "add-pane",
+  target: '[data-tour="add-pane"]',
+  title: "Add another AI chat panel",
+  body: "Bring in one more model.",
+  advance: "action",
+  allowInteraction: true,
+  hint: "Click + to add a panel",
+};
+
+describe("OnboardingTour view", () => {
+  it("renders nothing when idle", () => {
+    const { container } = renderWithProviders(
+      <OnboardingTour tour={makeController({ phase: "idle" })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("welcome phase shows the intro modal; Start tour advances", async () => {
+    const controller = makeController({ phase: "welcome" });
+    const { user } = renderWithProviders(<OnboardingTour tour={controller} />);
+
+    expect(screen.getByText("Welcome to Parallel AI")).toBeInTheDocument();
+    expect(screen.getByText(/Settings → About → Onboarding tour/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Start tour" }));
+    expect(controller.next).toHaveBeenCalled();
+  });
+
+  it("welcome Skip ends the tour", async () => {
+    const controller = makeController({ phase: "welcome" });
+    const { user } = renderWithProviders(<OnboardingTour tour={controller} />);
+    await user.click(screen.getByRole("button", { name: "Skip" }));
+    expect(controller.skip).toHaveBeenCalled();
+  });
+
+  it("finish phase celebrates with confetti", () => {
+    const { container } = renderWithProviders(
+      <OnboardingTour tour={makeController({ phase: "finish" })} />,
+    );
+    expect(screen.getByText("You're all set!")).toBeInTheDocument();
+    expect(container.querySelectorAll(".onboarding-confetti-piece").length).toBeGreaterThan(0);
+  });
+
+  it("finish phase omits confetti under reduced motion", () => {
+    const { container } = renderWithProviders(
+      <OnboardingTour tour={makeController({ phase: "finish", reducedMotion: true })} />,
+    );
+    expect(screen.getByText("You're all set!")).toBeInTheDocument();
+    expect(container.querySelectorAll(".onboarding-confetti-piece")).toHaveLength(0);
+  });
+
+  it("dims the whole screen until the target is measured", () => {
+    const { container } = renderWithProviders(
+      <OnboardingTour
+        tour={makeController({ phase: "step", step: layoutStep, targetRect: null })}
+      />,
+    );
+    expect(container.querySelector('[data-onboarding-phase="step"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-tour-step="layout"]')).toBeNull();
+  });
+
+  it("renders an info-step card with the layout sneak-peek", () => {
+    const controller = makeController({
+      phase: "step",
+      step: layoutStep,
+      stepIndex: 3,
+      stepCount: 11,
+      targetRect: fakeRect(),
+    });
+    const { container } = renderWithProviders(<OnboardingTour tour={controller} />);
+
+    expect(screen.getByText("Choose your layout")).toBeInTheDocument();
+    expect(screen.getByText("Step 4 / 11")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
+
+    const showcase = container.querySelector('[data-tour-showcase="layouts"]');
+    expect(showcase).toBeInTheDocument();
+    for (const label of ["1×3", "2×2", "3×3"]) {
+      expect(within(showcase as HTMLElement).getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("renders an action-step hint pill and Skip step", () => {
+    const controller = makeController({
+      phase: "step",
+      step: actionStep,
+      stepIndex: 7,
+      targetRect: fakeRect(),
+    });
+    renderWithProviders(<OnboardingTour tour={controller} />);
+    expect(screen.getByText("Click + to add a panel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Skip step" })).toBeInTheDocument();
+  });
+
+  it("shows Finish on the last step", () => {
+    const controller = makeController({
+      phase: "step",
+      step: { id: "settings", target: '[data-tour="settings"]', title: "Make it yours", body: "Pick providers." },
+      stepIndex: 10,
+      stepCount: 11,
+      targetRect: fakeRect(),
+    });
+    renderWithProviders(<OnboardingTour tour={controller} />);
+    expect(screen.getByRole("button", { name: "Finish" })).toBeInTheDocument();
+  });
+
+  it("surfaces the highlighted control's tooltip", () => {
+    const controller = makeController({
+      phase: "step",
+      step: { id: "settings", target: '[data-tour="settings"]', title: "Make it yours", body: "Pick providers." },
+      targetRect: fakeRect(),
+      activeTooltip: { text: "Settings", placement: "bottom" },
+    });
+    const { container } = renderWithProviders(<OnboardingTour tour={controller} />);
+    const tip = container.querySelector(".app-tooltip");
+    expect(tip).toBeInTheDocument();
+    expect(tip).toHaveTextContent("Settings");
+  });
+});

--- a/tests/multi-panel/onboarding/onboarding-storage.test.ts
+++ b/tests/multi-panel/onboarding/onboarding-storage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { readStorage, seedStorage } from "../../setup/chrome-mock";
+import {
+  ONBOARDING_STATE_KEY,
+  TOUR_VERSION,
+  markTourCompleted,
+  readOnboardingState,
+  resetOnboarding,
+  shouldShowTour,
+} from "@/multi-panel/onboarding/onboarding-storage";
+
+describe("onboarding-storage", () => {
+  it("defaults to completedVersion 0 when nothing is stored", async () => {
+    expect(await readOnboardingState()).toEqual({ completedVersion: 0 });
+  });
+
+  it("shows the tour for a fresh install", async () => {
+    expect(await shouldShowTour()).toBe(true);
+  });
+
+  it("markTourCompleted writes the current TOUR_VERSION and suppresses the tour", async () => {
+    await markTourCompleted();
+    expect(readStorage("local")[ONBOARDING_STATE_KEY]).toEqual({
+      completedVersion: TOUR_VERSION,
+    });
+    expect(await shouldShowTour()).toBe(false);
+  });
+
+  it("does not re-show once the current version has been completed", async () => {
+    seedStorage("local", { [ONBOARDING_STATE_KEY]: { completedVersion: TOUR_VERSION } });
+    expect(await shouldShowTour()).toBe(false);
+  });
+
+  it("re-shows after a future tour version bump", async () => {
+    seedStorage("local", { [ONBOARDING_STATE_KEY]: { completedVersion: TOUR_VERSION - 1 } });
+    expect(await shouldShowTour()).toBe(true);
+  });
+
+  it("resetOnboarding re-arms the tour (used by Replay)", async () => {
+    await markTourCompleted();
+    await resetOnboarding();
+    expect(readStorage("local")[ONBOARDING_STATE_KEY]).toEqual({ completedVersion: 0 });
+    expect(await shouldShowTour()).toBe(true);
+  });
+
+  it("ignores malformed stored state", async () => {
+    seedStorage("local", { [ONBOARDING_STATE_KEY]: { completedVersion: "nope" } });
+    expect(await readOnboardingState()).toEqual({ completedVersion: 0 });
+  });
+
+  it("no-ops gracefully without chrome.storage", async () => {
+    const holder = globalThis as { chrome?: typeof chrome };
+    const original = holder.chrome;
+    delete holder.chrome;
+    try {
+      expect(await readOnboardingState()).toEqual({ completedVersion: 0 });
+      await expect(markTourCompleted()).resolves.toBeUndefined();
+    } finally {
+      holder.chrome = original;
+    }
+  });
+});

--- a/tests/multi-panel/onboarding/useOnboardingTour.test.ts
+++ b/tests/multi-panel/onboarding/useOnboardingTour.test.ts
@@ -1,0 +1,287 @@
+import { act, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { readStorage, seedStorage } from "../../setup/chrome-mock";
+import { renderHookWithProviders } from "../../helpers/hook";
+import { ONBOARDING_STATE_KEY, TOUR_VERSION } from "@/multi-panel/onboarding/onboarding-storage";
+import type { TourActions, TourContext } from "@/multi-panel/onboarding/tour-steps";
+import { useOnboardingTour } from "@/multi-panel/onboarding/useOnboardingTour";
+
+function installTourTargets() {
+  const container = document.createElement("div");
+  for (const id of [
+    "composer-input",
+    "composer-bar",
+    "send-all",
+    "layout",
+    "prompt-library",
+    "manage-prompts",
+    "scroll-sync",
+    "add-pane",
+    "settings",
+  ]) {
+    const button = document.createElement("button");
+    button.setAttribute("data-tour", id);
+    container.append(button);
+  }
+  // Two panel capsules; the close button lives in the second (the "new" pane),
+  // so resolve:"last" targeting lands on it.
+  for (let i = 0; i < 2; i += 1) {
+    const capsule = document.createElement("div");
+    capsule.setAttribute("data-panel-control-capsule", "");
+    if (i === 1) {
+      const close = document.createElement("button");
+      close.setAttribute("data-tour", "panel-close");
+      capsule.append(close);
+    }
+    container.append(capsule);
+  }
+  document.body.append(container);
+}
+
+function makeContext(overrides: Partial<TourContext> = {}): TourContext {
+  return {
+    activePanelCount: 3,
+    promptQuickPickOpen: false,
+    ...overrides,
+  };
+}
+
+function renderTour(initial: { ready: boolean; context: TourContext }, actions: TourActions) {
+  return renderHookWithProviders(
+    ({ ready, context }: { ready: boolean; context: TourContext }) =>
+      useOnboardingTour({ ready, context, actions }),
+    { initialProps: initial },
+  );
+}
+
+let actions: TourActions;
+
+beforeEach(() => {
+  // Stub rAF so the measure loop stays inert; navigation uses synchronous
+  // selector resolution, which is what these tests exercise.
+  vi.stubGlobal("requestAnimationFrame", vi.fn(() => 0));
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  installTourTargets();
+  actions = {
+    openPromptQuickPick: vi.fn(),
+    closePromptQuickPick: vi.fn(),
+  };
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useOnboardingTour auto-start", () => {
+  it("auto-starts at the welcome phase for a fresh install", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+  });
+
+  it("does not start when the current version was already completed", async () => {
+    seedStorage("local", { [ONBOARDING_STATE_KEY]: { completedVersion: TOUR_VERSION } });
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await flushMicrotasks();
+    expect(result.current.phase).toBe("idle");
+  });
+
+  it("does not start until the app is ready", async () => {
+    const { result } = renderTour({ ready: false, context: makeContext() }, actions);
+    await flushMicrotasks();
+    expect(result.current.phase).toBe("idle");
+  });
+});
+
+describe("useOnboardingTour navigation", () => {
+  it("welcome -> first step, with a step counter", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+
+    await act(async () => result.current.next());
+    expect(result.current.phase).toBe("step");
+    expect(result.current.step?.id).toBe("composer-input");
+    expect(result.current.stepIndex).toBe(0);
+    expect(result.current.stepCount).toBeGreaterThan(5);
+  });
+
+  it("back from the first step returns to welcome", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+    await act(async () => result.current.next());
+    await act(async () => result.current.back());
+    expect(result.current.phase).toBe("welcome");
+  });
+
+  it("ArrowRight advances and ArrowLeft goes back", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    });
+    expect(result.current.phase).toBe("step");
+    expect(result.current.step?.id).toBe("composer-input");
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight" }));
+    });
+    expect(result.current.step?.id).toBe("composer-bar");
+
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft" }));
+    });
+    expect(result.current.step?.id).toBe("composer-input");
+  });
+
+  it("ignores arrow keys while the user is typing in a non-empty input", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+    await act(async () => result.current.next());
+    expect(result.current.step?.id).toBe("composer-input");
+
+    const input = document.createElement("input");
+    input.value = "draft query";
+    document.body.append(input);
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    // Cursor navigation in the field must win — the tour must not advance.
+    expect(result.current.step?.id).toBe("composer-input");
+    input.remove();
+  });
+
+  it("still navigates when a focused field is empty (auto-focused popover search)", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+    await act(async () => result.current.next());
+    expect(result.current.step?.id).toBe("composer-input");
+
+    const input = document.createElement("input");
+    document.body.append(input);
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    // Empty field: arrows do nothing there, so they drive the tour instead.
+    expect(result.current.step?.id).toBe("composer-bar");
+    input.remove();
+  });
+
+  it("skip ends the tour and records completion", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+    await act(async () => result.current.skip());
+    expect(result.current.phase).toBe("idle");
+    await waitFor(() =>
+      expect(readStorage("local")[ONBOARDING_STATE_KEY]).toEqual({
+        completedVersion: TOUR_VERSION,
+      }),
+    );
+  });
+
+  it("walking Next past the last step reaches the finish phase", async () => {
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+    for (let i = 0; i < 20 && result.current.phase !== "finish"; i += 1) {
+      await act(async () => result.current.next());
+    }
+    expect(result.current.phase).toBe("finish");
+  });
+
+  it("skips a step whose target is absent", async () => {
+    document.querySelector('[data-tour="composer-bar"]')?.remove();
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+    await act(async () => result.current.next()); // -> composer-input
+    expect(result.current.step?.id).toBe("composer-input");
+    await act(async () => result.current.next()); // composer-bar missing -> send-all
+    expect(result.current.step?.id).toBe("send-all");
+  });
+});
+
+describe("useOnboardingTour action steps", () => {
+  async function advanceTo(result: { current: ReturnType<typeof useOnboardingTour> }, id: string) {
+    await waitFor(() => expect(result.current.phase).toBe("welcome"));
+    for (let i = 0; i < 20 && result.current.step?.id !== id; i += 1) {
+      await act(async () => result.current.next());
+    }
+    expect(result.current.step?.id).toBe(id);
+  }
+
+  it("add-pane advances when the active panel count rises", async () => {
+    const { result, rerender } = renderTour(
+      { ready: true, context: makeContext({ activePanelCount: 3 }) },
+      actions,
+    );
+    await advanceTo(result, "add-pane");
+
+    await act(async () => {
+      rerender({ ready: true, context: makeContext({ activePanelCount: 4 }) });
+    });
+
+    expect(result.current.step?.id).toBe("panel-controls");
+  });
+
+  it("close-pane advances when the active panel count drops", async () => {
+    const { result, rerender } = renderTour(
+      { ready: true, context: makeContext({ activePanelCount: 4 }) },
+      actions,
+    );
+    await advanceTo(result, "close-pane");
+
+    await act(async () => {
+      rerender({ ready: true, context: makeContext({ activePanelCount: 3 }) });
+    });
+
+    expect(result.current.step?.id).toBe("settings");
+  });
+
+  it("prompt-library advances when the quick-pick popover opens", async () => {
+    const { result, rerender } = renderTour(
+      { ready: true, context: makeContext({ promptQuickPickOpen: false }) },
+      actions,
+    );
+    await advanceTo(result, "prompt-library");
+    expect(actions.closePromptQuickPick).toHaveBeenCalled(); // onEnter
+
+    await act(async () => {
+      rerender({ ready: true, context: makeContext({ promptQuickPickOpen: true }) });
+    });
+
+    expect(result.current.step?.id).toBe("manage-prompts");
+  });
+
+  it("manage-prompts re-opens the popover if it closes (keep-open guard)", async () => {
+    const { result, rerender } = renderTour(
+      { ready: true, context: makeContext({ promptQuickPickOpen: true }) },
+      actions,
+    );
+    await advanceTo(result, "manage-prompts");
+    (actions.openPromptQuickPick as ReturnType<typeof vi.fn>).mockClear();
+
+    await act(async () => {
+      rerender({ ready: true, context: makeContext({ promptQuickPickOpen: false }) });
+    });
+
+    expect(actions.openPromptQuickPick).toHaveBeenCalled();
+  });
+});
+
+describe("useOnboardingTour replay", () => {
+  it("start() shows the tour regardless of stored completion", async () => {
+    seedStorage("local", { [ONBOARDING_STATE_KEY]: { completedVersion: TOUR_VERSION } });
+    const { result } = renderTour({ ready: true, context: makeContext() }, actions);
+    await flushMicrotasks();
+    expect(result.current.phase).toBe("idle");
+
+    await act(async () => result.current.start());
+    expect(result.current.phase).toBe("welcome");
+  });
+});

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -69,6 +69,21 @@ describe("background service worker", () => {
     );
   });
 
+  it("onInstalled opens the workspace on a fresh install", async () => {
+    await listeners.onInstalled[0]!({ reason: "install" });
+    expect(chrome.tabs.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining("multi-panel/index.html"),
+        active: true,
+      }),
+    );
+  });
+
+  it("onInstalled does not open a tab on update", async () => {
+    await listeners.onInstalled[0]!({ reason: "update" });
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
   it("onStartup also creates the context menu", async () => {
     await listeners.onStartup[0]!();
     expect(chrome.contextMenus.create).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
Adds an interactive, version-gated onboarding tour that greets new and existing users once after install/update and can be replayed anytime from **Settings → About**.

- 11 spotlight coach-mark steps anchored to real composer/panel controls via `data-tour` attributes (never the cross-origin provider iframes).
- Hands-on action steps — drag the composer, open the prompt popover, add/close a panel — that auto-advance when the interaction happens.
- Layout step floats a "sneak peek" of 1×3 / 2×2 / 3×3 previews so users see what the picker offers without opening it.
- Keyboard navigation (←/→ to move, Esc to exit) with arrow hints on the buttons; real hover tooltips on the per-panel-controls step.
- Confetti finish celebration (no library), reduced-motion aware.
- State persisted in `chrome.storage.local` (device-local, outside synced settings). Service worker opens the workspace on install so the tour appears immediately.

## Test plan
- `tsc --noEmit` — clean
- Unit + coverage — 534/534, statements 73.1% (above the 72% gate)
- `vite build` + shippable check — pass
- Full Playwright E2E — 11/11 (full tour walkthrough with per-step screenshots + replay-from-Settings, plus the rest of the fixtures suite)
