### PR TITLE
De-flake pending-action e2e test

### DIFF
--- a/tests/e2e/fixtures/pending-action.spec.ts
+++ b/tests/e2e/fixtures/pending-action.spec.ts
@@ -3,16 +3,17 @@ import { expect, test } from "../_fixtures";
 import { PENDING_MULTI_PANEL_ACTION_KEY } from "../../../src/shared/lib/constants";
 
 test.describe("pending action handoff", () => {
-  test("prefills the composer from a pending sendToPanel action", async ({
-    context,
-    extensionId,
-    openMultiPanel,
-  }) => {
-    await context.addInitScript(
-      ({ key, payload }) => {
-        void chrome.storage.session.set({
-          [key]: payload,
-        });
+  test("prefills the composer from a pending sendToPanel action", async ({ openMultiPanel }) => {
+    const page = await openMultiPanel();
+    // Let the app hydrate so its one-shot pending-action read runs against empty
+    // storage first — otherwise it consumes and clears the seed below.
+    await expect(page.locator("textarea").first()).toBeVisible({ timeout: 10_000 });
+
+    // Seed deterministically: an awaited write + reload so the app reads a
+    // committed value (a fire-and-forget seed raced that read and was flaky).
+    await page.evaluate(
+      async ({ key, payload }) => {
+        await chrome.storage.session.set({ [key]: payload });
       },
       {
         key: PENDING_MULTI_PANEL_ACTION_KEY,
@@ -22,9 +23,7 @@ test.describe("pending action handoff", () => {
         },
       },
     );
-
-    const page = await openMultiPanel();
-    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+    await page.reload();
 
     const composer = page.locator("textarea").first();
     await expect(composer).toHaveValue("selection from context menu", { timeout: 10_000 });


### PR DESCRIPTION
## Summary
The `pending-action` e2e test is flaky (~40% failure per attempt, masked by CI retries) and turned `main` red right after the onboarding PR merged.

**Root cause:** it seeded `chrome.storage.session` with a fire-and-forget `addInitScript`, which raced the controller's one-shot read on hydration. The app reads the key exactly once with no change listener, so a missed/late write leaves the composer empty.

**Fix (test-only):** seed deterministically —
1. wait for the composer to render (the app's initial empty read has already run, so it won't consume/clear the seed),
2. write the pending action with an **awaited** `chrome.storage.session.set` (committed),
3. `reload()` so the app reads the committed value on a fresh mount.

## Test plan
- `tsc --noEmit` — clean
- `pending-action` ×12 with `--retries=0` — **12/12** (the original was 3/5)
- Full e2e suite — **11/11**
