### PR TITLE
Add Chrome Web Store release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: release
+
+# Cut a release by bumping manifest.json, committing to main, then tagging:
+#   git tag v1.0.4 && git push origin v1.0.4
+# This builds, gates on tests, and submits the package to the Chrome Web Store
+# for review. The store listing (description, screenshots) is managed in the
+# dashboard and is untouched here.
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: build + submit to Chrome Web Store
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify tag matches manifest version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          MANIFEST=$(node -p "require('./manifest.json').version")
+          echo "Tag version:      $TAG"
+          echo "Manifest version: $MANIFEST"
+          if [ "$TAG" != "$MANIFEST" ]; then
+            echo "::error::Tag v$TAG does not match manifest.json version $MANIFEST. Bump manifest.json and re-tag."
+            exit 1
+          fi
+
+      - name: Run tests
+        run: bun run test
+
+      - name: Build + zip
+        run: bun run package
+
+      - name: Submit to Chrome Web Store
+        env:
+          CWS_EXTENSION_ID: ${{ secrets.CWS_EXTENSION_ID }}
+          CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+        run: bun scripts/publish-cws.mjs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing
+
+This project deploys to the Chrome Web Store automatically. Pushing a
+`vMAJOR.MINOR.PATCH` tag builds the extension, runs the tests, and submits the
+package to the store for review.
+
+## Cutting a release
+
+1. Update `version` in `manifest.json` (must be greater than the version
+   currently live in the store).
+2. Commit and merge to `main`.
+3. Tag the release commit and push the tag:
+
+   ```bash
+   git tag v1.0.4
+   git push origin v1.0.4
+   ```
+
+4. Watch the **release** workflow under the repo's Actions tab. It will:
+   - fail fast if the tag does not match `manifest.json`'s version,
+   - run `bun run test`,
+   - build and zip (`bun run package`),
+   - upload the zip and submit it for review.
+
+Google's review then takes anywhere from a few hours to a few days. The store
+listing (description, screenshots, category) is managed in the dashboard and is
+not touched by this pipeline.
+
+## Required GitHub secrets
+
+Set these under Settings -> Secrets and variables -> Actions:
+
+| Secret | Where it comes from |
+| --- | --- |
+| `CWS_EXTENSION_ID` | The 32-character ID in the store URL. |
+| `CWS_CLIENT_ID` | OAuth client (Google Cloud), ends in `.apps.googleusercontent.com`. |
+| `CWS_CLIENT_SECRET` | OAuth client secret, starts with `GOCSPX-`. |
+| `CWS_REFRESH_TOKEN` | Minted once with `scripts/mint-cws-token.mjs`. |
+
+## One-time token setup
+
+The first three secrets come from a Google Cloud project with the **Chrome Web
+Store API** enabled and an OAuth client of type **Desktop app**. To mint the
+refresh token:
+
+```bash
+bun scripts/mint-cws-token.mjs "/path/to/client_secret_xxx.json"
+```
+
+Open the printed URL, sign in with a Chrome Web Store developer account for this
+extension, click through the unverified-app screen, and grant access. The script
+prints the refresh token.
+
+Set the OAuth consent screen to **In production** (not Testing) or the refresh
+token expires after 7 days.
+
+## Troubleshooting
+
+- **Tag/manifest mismatch**: the workflow fails before building. Bump
+  `manifest.json`, delete the bad tag (`git push origin :v1.0.4`), then re-tag.
+- **Upload rejected as duplicate version**: the version already exists in the
+  store. Bump `manifest.json` and re-tag.
+- **Token refresh fails**: the refresh token expired (consent screen still in
+  Testing) or was revoked. Re-mint it and update the secret.

--- a/scripts/mint-cws-token.mjs
+++ b/scripts/mint-cws-token.mjs
@@ -13,12 +13,14 @@
 //   # or via env vars instead of the JSON path:
 //   CWS_CLIENT_ID=... CWS_CLIENT_SECRET=... bun scripts/mint-cws-token.mjs
 
+import { randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
 
 const SCOPE = "https://www.googleapis.com/auth/chromewebstore";
 const PORT = 4100;
-const REDIRECT_URI = `http://localhost:${PORT}`;
+const REDIRECT_URI = `http://127.0.0.1:${PORT}`;
+const STATE = randomBytes(16).toString("hex"); // CSRF guard for the loopback redirect
 
 function loadCreds() {
   const jsonPath = process.argv[2];
@@ -49,6 +51,7 @@ const authUrl =
     scope: SCOPE,
     access_type: "offline", // ask for a refresh token
     prompt: "consent", // force one to be issued even on re-auth
+    state: STATE,
   });
 
 const server = createServer(async (req, res) => {
@@ -57,6 +60,12 @@ const server = createServer(async (req, res) => {
   if (!code) {
     res.writeHead(204).end();
     return;
+  }
+  if (url.searchParams.get("state") !== STATE) {
+    res.writeHead(400).end("State mismatch — aborting.");
+    console.error("\n✗ OAuth state mismatch (possible CSRF) — aborting.");
+    server.close();
+    process.exit(1);
   }
   try {
     const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
@@ -83,6 +92,7 @@ const server = createServer(async (req, res) => {
     console.log("\n=== CWS_REFRESH_TOKEN (copy this into your GitHub secrets) ===\n");
     console.log(data.refresh_token);
     console.log("\n=============================================================\n");
+    clearTimeout(timeout);
     server.close();
     process.exit(0);
   } catch (err) {
@@ -93,7 +103,17 @@ const server = createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, () => {
+// Don't hang forever if the browser flow is never completed.
+const timeout = setTimeout(
+  () => {
+    console.error("\n✗ Timed out after 5 minutes waiting for the OAuth redirect.");
+    server.close();
+    process.exit(1);
+  },
+  5 * 60 * 1000,
+);
+
+server.listen(PORT, "127.0.0.1", () => {
   console.log("\nOpen this URL in your browser, sign in, and grant access:\n");
   console.log(authUrl.toString());
   console.log("\n(Waiting for the redirect on " + REDIRECT_URI + " ...)\n");

--- a/scripts/mint-cws-token.mjs
+++ b/scripts/mint-cws-token.mjs
@@ -1,0 +1,100 @@
+// One-time helper: mints a Chrome Web Store API refresh token.
+//
+// Runs the OAuth "loopback" flow for a Desktop-app client: it starts a local
+// server, sends you to Google sign-in, catches the redirect, exchanges the
+// code, and prints the refresh token you store as the CWS_REFRESH_TOKEN secret.
+//
+// Nothing secret is stored here — the client id/secret come from the OAuth
+// client JSON you downloaded from Google Cloud (pass its path), and the refresh
+// token is printed once for you to copy into GitHub secrets.
+//
+// Usage:
+//   bun scripts/mint-cws-token.mjs "/c/Users/you/Downloads/client_secret_xxx.json"
+//   # or via env vars instead of the JSON path:
+//   CWS_CLIENT_ID=... CWS_CLIENT_SECRET=... bun scripts/mint-cws-token.mjs
+
+import { readFileSync } from "node:fs";
+import { createServer } from "node:http";
+
+const SCOPE = "https://www.googleapis.com/auth/chromewebstore";
+const PORT = 4100;
+const REDIRECT_URI = `http://localhost:${PORT}`;
+
+function loadCreds() {
+  const jsonPath = process.argv[2];
+  if (jsonPath) {
+    const parsed = JSON.parse(readFileSync(jsonPath, "utf8"));
+    const c = parsed.installed ?? parsed.web ?? parsed;
+    return { clientId: c.client_id, clientSecret: c.client_secret };
+  }
+  return {
+    clientId: process.env.CWS_CLIENT_ID,
+    clientSecret: process.env.CWS_CLIENT_SECRET,
+  };
+}
+
+const { clientId, clientSecret } = loadCreds();
+if (!clientId || !clientSecret) {
+  console.error("Missing client credentials. Pass the OAuth client JSON path:");
+  console.error('  bun scripts/mint-cws-token.mjs "/path/to/client_secret_xxx.json"');
+  process.exit(1);
+}
+
+const authUrl =
+  "https://accounts.google.com/o/oauth2/v2/auth?" +
+  new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: REDIRECT_URI,
+    response_type: "code",
+    scope: SCOPE,
+    access_type: "offline", // ask for a refresh token
+    prompt: "consent", // force one to be issued even on re-auth
+  });
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, REDIRECT_URI);
+  const code = url.searchParams.get("code");
+  if (!code) {
+    res.writeHead(204).end();
+    return;
+  }
+  try {
+    const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: REDIRECT_URI,
+        grant_type: "authorization_code",
+      }),
+    });
+    const data = await tokenRes.json();
+    if (!data.refresh_token) {
+      res.writeHead(500).end("No refresh_token returned — see terminal.");
+      console.error("\nToken response had no refresh_token:\n", data);
+      server.close();
+      process.exit(1);
+    }
+    res
+      .writeHead(200, { "Content-Type": "text/html" })
+      .end("<h2>Refresh token minted.</h2><p>Back to your terminal — you can close this tab.</p>");
+    console.log("\n=== CWS_REFRESH_TOKEN (copy this into your GitHub secrets) ===\n");
+    console.log(data.refresh_token);
+    console.log("\n=============================================================\n");
+    server.close();
+    process.exit(0);
+  } catch (err) {
+    res.writeHead(500).end("Token exchange failed — see terminal.");
+    console.error(err);
+    server.close();
+    process.exit(1);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log("\nOpen this URL in your browser, sign in, and grant access:\n");
+  console.log(authUrl.toString());
+  console.log("\n(Waiting for the redirect on " + REDIRECT_URI + " ...)\n");
+});

--- a/scripts/publish-cws.mjs
+++ b/scripts/publish-cws.mjs
@@ -1,0 +1,96 @@
+// Publishes the built extension zip to the Chrome Web Store.
+//
+// Three calls against the CWS API: refresh an access token, upload the
+// package, then submit it for review. Everything comes from the environment so
+// nothing is hardcoded:
+//   CWS_EXTENSION_ID, CWS_CLIENT_ID, CWS_CLIENT_SECRET, CWS_REFRESH_TOKEN
+//
+// The zip path is derived from dist/manifest.json's version (matching the name
+// zip-dist.mjs writes), or pass an explicit path as argv[2].
+
+import { existsSync, readFileSync } from "node:fs";
+
+const { CWS_EXTENSION_ID, CWS_CLIENT_ID, CWS_CLIENT_SECRET, CWS_REFRESH_TOKEN } = process.env;
+
+for (const [name, value] of Object.entries({
+  CWS_EXTENSION_ID,
+  CWS_CLIENT_ID,
+  CWS_CLIENT_SECRET,
+  CWS_REFRESH_TOKEN,
+})) {
+  if (!value) {
+    console.error(`✗ Missing required env var: ${name}`);
+    process.exit(1);
+  }
+}
+
+function resolveZip() {
+  if (process.argv[2]) return process.argv[2];
+  const manifest = JSON.parse(readFileSync("dist/manifest.json", "utf8"));
+  return `parallel-ai-v${manifest.version}.zip`;
+}
+
+const ZIP = resolveZip();
+if (!existsSync(ZIP)) {
+  console.error(`✗ Zip not found: ${ZIP} — run \`bun run package\` first.`);
+  process.exit(1);
+}
+
+async function getAccessToken() {
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: CWS_CLIENT_ID,
+      client_secret: CWS_CLIENT_SECRET,
+      refresh_token: CWS_REFRESH_TOKEN,
+      grant_type: "refresh_token",
+    }),
+  });
+  const data = await res.json();
+  if (!data.access_token) {
+    throw new Error(`Token refresh failed: ${JSON.stringify(data)}`);
+  }
+  return data.access_token;
+}
+
+async function uploadPackage(token) {
+  const res = await fetch(
+    `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CWS_EXTENSION_ID}`,
+    {
+      method: "PUT",
+      headers: { Authorization: `Bearer ${token}`, "x-goog-api-version": "2" },
+      body: readFileSync(ZIP),
+    },
+  );
+  const data = await res.json();
+  // A 200 with uploadState FAILURE still means it didn't take — check the body.
+  if (data.uploadState !== "SUCCESS") {
+    throw new Error(`Upload not successful: ${JSON.stringify(data)}`);
+  }
+  console.log(`✓ Uploaded ${ZIP}`);
+}
+
+async function submitForReview(token) {
+  const res = await fetch(
+    `https://www.googleapis.com/chromewebstore/v1.1/items/${CWS_EXTENSION_ID}/publish`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "x-goog-api-version": "2",
+        "Content-Length": "0",
+      },
+    },
+  );
+  const data = await res.json();
+  if (!Array.isArray(data.status) || !data.status.includes("OK")) {
+    throw new Error(`Publish failed: ${JSON.stringify(data)}`);
+  }
+  console.log(`✓ Submitted for review (status: ${data.status.join(", ")})`);
+}
+
+const token = await getAccessToken();
+await uploadPackage(token);
+await submitForReview(token);
+console.log("✓ Done — Chrome Web Store review submitted. Google's review can take hours to days.");

--- a/scripts/publish-cws.mjs
+++ b/scripts/publish-cws.mjs
@@ -56,7 +56,7 @@ async function getAccessToken() {
 
 async function uploadPackage(token) {
   const res = await fetch(
-    `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CWS_EXTENSION_ID}`,
+    `https://www.googleapis.com/upload/chromewebstore/v1.1/items/${CWS_EXTENSION_ID}?uploadType=media`,
     {
       method: "PUT",
       headers: { Authorization: `Bearer ${token}`, "x-goog-api-version": "2" },


### PR DESCRIPTION
## What

Adds continuous deployment to the Chrome Web Store. Pushing a `vMAJOR.MINOR.PATCH` tag now builds, tests, and submits the extension for review automatically.

## Changes

- **`.github/workflows/release.yml`** - tag-triggered (`v*.*.*`) workflow. Verifies the tag matches `manifest.json`'s version, runs `bun run test`, builds + zips (`bun run package`), then submits to the store.
- **`scripts/publish-cws.mjs`** - refreshes an access token, uploads the zip, and submits for review via the Chrome Web Store API. No third-party action handles the secrets.
- **`scripts/mint-cws-token.mjs`** - one-time helper to mint the OAuth refresh token (loopback flow for a Desktop client). Useful for teammates setting up their own token.
- **`RELEASING.md`** - how to cut a release, the required secrets, and the one-time token setup.

## Notes

- Inert until a tag is pushed; nothing deploys on merge.
- Requires four repo secrets: `CWS_EXTENSION_ID`, `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` (already configured).
- The store listing (description, screenshots) is managed in the dashboard and is untouched by this pipeline.