### PR TITLE
Restore provider chat sessions on reload (session persistence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Vitest runs against the `src/shared/lib/*` modules with `happy-dom` and `fake-in
 
 ## Roadmap / known limits
 
+- Planned features and design specs live in [docs/roadmap/](docs/roadmap/README.md).
 - Provider sites change their DOMs frequently; selectors in `content-scripts/text-injection-*.js` and `content-scripts/enter-behavior-*.js` may need touch-ups when that happens.
 - Some providers occasionally refuse iframing despite header stripping; reload the panel from the panel header if a provider fails to load.
 - Temporary-chat support is provider-dependent (currently ChatGPT, Claude, Gemini, Grok, Qwen).

--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -14,6 +14,7 @@
   const PARALLEL_AI_PROVIDER_URL = 'PARALLEL_AI_PROVIDER_URL';
   const PARALLEL_AI_PROVIDER_TITLE = 'PARALLEL_AI_PROVIDER_TITLE';
   const PARALLEL_AI_TEMP_CHAT_ENABLED = 'PARALLEL_AI_TEMP_CHAT_ENABLED';
+  const PARALLEL_AI_TEMP_CHAT_DISABLED = 'PARALLEL_AI_TEMP_CHAT_DISABLED';
   const CHATGPT_STOP_BUTTON_SELECTOR = 'button[data-testid="stop-button"]';
   const CHATGPT_SEND_TRACKING_IDLE_DELAY_MS = 800;
   const CHATGPT_SEND_TRACKING_NO_BUSY_TIMEOUT_MS = 2000;
@@ -456,8 +457,14 @@
     chatgpt: ['button[aria-label="Turn on temporary chat"]'],
     claude: ['button[aria-label="Use incognito"]'],
     gemini: [
-      'button[data-test-id="temp-chat-button"]',
-      'button[aria-label="Temporary chat"]'
+      // The clickable control is the inner <button>; the temp-chat-button
+      // data-test-id / .temp-chat-on state now live on the wrapping
+      // <gem-icon-button>, so match the button by its label first and fall
+      // back to the wrapper (older builds put the attribute on the button).
+      'gem-icon-button[data-test-id="temp-chat-button"] button',
+      'button[aria-label="Temporary chat"]',
+      'gem-icon-button[data-test-id="temp-chat-button"]',
+      'button[data-test-id="temp-chat-button"]'
     ],
     grok: ['a[href="/c#private"][aria-label="Switch to Private Chat"]'],
     qwen: [
@@ -1000,6 +1007,18 @@
 
     window.parent.postMessage({
       type: PARALLEL_AI_TEMP_CHAT_ENABLED,
+      provider,
+      context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
+    }, '*');
+  }
+
+  function postTemporaryChatDisabled(provider = detectProvider()) {
+    if (!provider || window.parent === window) {
+      return;
+    }
+
+    window.parent.postMessage({
+      type: PARALLEL_AI_TEMP_CHAT_DISABLED,
       provider,
       context: MULTI_PANEL_PROVIDER_STATUS_CONTEXT
     }, '*');
@@ -2305,14 +2324,27 @@
 
   function isGeminiTemporaryChatEnabled(control = null) {
     const button = control ||
-      document.querySelector('button[data-test-id="temp-chat-button"]') ||
-      document.querySelector('button[aria-label="Temporary chat"]');
+      document.querySelector('gem-icon-button[data-test-id="temp-chat-button"]') ||
+      document.querySelector('button[aria-label="Temporary chat"]') ||
+      document.querySelector('[data-test-id="temp-chat-button"]');
 
     if (!button) {
       return false;
     }
 
-    return button.classList.contains('temp-chat-on') || isTemporaryChatControlActive(button);
+    // The "on" state is expressed by a `temp-chat-on` class on the
+    // <gem-icon-button> wrapper, not on the inner <button>. Depending on which
+    // selector matched, `button` may be that wrapper, its descendant, or its
+    // ancestor — so check the class across the whole local subtree/ancestry.
+    if (
+      button.classList.contains('temp-chat-on') ||
+      (typeof button.closest === 'function' && button.closest('.temp-chat-on')) ||
+      (typeof button.querySelector === 'function' && button.querySelector('.temp-chat-on'))
+    ) {
+      return true;
+    }
+
+    return isTemporaryChatControlActive(button);
   }
 
   function isTemporaryChatAlreadyEnabled(provider, control = null) {
@@ -2357,6 +2389,39 @@
       if (button && isElementEnabled(button)) {
         if (clickElement(button)) {
           postTemporaryChatEnabled(provider);
+          return true;
+        }
+      }
+
+      await sleep(TEMP_CHAT_POLL_INTERVAL_MS);
+    }
+
+    return false;
+  }
+
+  // Mirror of enableTemporaryChat for providers whose temp/normal URLs are
+  // identical (Gemini, Qwen): their iframe never reloads to a normal URL, so
+  // turning temp mode off requires clicking the in-page toggle. Only click when
+  // it is currently on, so we never accidentally re-enable it.
+  async function disableTemporaryChat(provider) {
+    const selectors = TEMP_CHAT_BUTTON_SELECTORS[provider];
+    if (!selectors || selectors.length === 0) {
+      return false;
+    }
+
+    const deadline = Date.now() + TEMP_CHAT_POLL_TIMEOUT_MS;
+    while (Date.now() <= deadline) {
+      const button = findDeepFirstVisibleElement(selectors) || findFirstVisibleElement(selectors);
+
+      if (button) {
+        if (!isTemporaryChatAlreadyEnabled(provider, button)) {
+          // Already in a normal chat — nothing to toggle.
+          postTemporaryChatDisabled(provider);
+          return true;
+        }
+
+        if (isElementEnabled(button) && clickElement(button)) {
+          postTemporaryChatDisabled(provider);
           return true;
         }
       }
@@ -3137,6 +3202,15 @@
       const provider = detectProvider();
       if (provider) {
         void enableTemporaryChat(provider);
+        setTimeout(() => scheduleProviderInputAnchorReport('temp-chat'), 800);
+      }
+      return;
+    }
+
+    if (event.data.type === 'DISABLE_TEMP_CHAT' && event.data.context === 'multi-panel') {
+      const provider = detectProvider();
+      if (provider) {
+        void disableTemporaryChat(provider);
         setTimeout(() => scheduleProviderInputAnchorReport('temp-chat'), 800);
       }
       return;

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,12 +1,12 @@
 # Roadmap / Feature Backlog
 
-Planned features and design specs that are not yet implemented. Each entry links
-to a detailed spec covering the problem, the resolved design decisions, and an
+Design specs and delivery status for roadmap features. Each entry links to a
+detailed spec covering the problem, the resolved design decisions, and an
 implementation plan.
 
 | Feature | Status | Spec |
 | --- | --- | --- |
-| Session persistence (restore parallel chats on launch) | Planned (Phase 1 spec'd) | [session-persistence.md](session-persistence.md) |
+| Session persistence (restore parallel chats on launch) | Shipped (v1.0.3) | [session-persistence.md](session-persistence.md) |
 
 ## Status legend
 

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,15 @@
+# Roadmap / Feature Backlog
+
+Planned features and design specs that are not yet implemented. Each entry links
+to a detailed spec covering the problem, the resolved design decisions, and an
+implementation plan.
+
+| Feature | Status | Spec |
+| --- | --- | --- |
+| Session persistence (restore parallel chats on launch) | Planned (Phase 1 spec'd) | [session-persistence.md](session-persistence.md) |
+
+## Status legend
+
+- Planned: spec written, implementation not started.
+- In progress: implementation underway.
+- Shipped: merged; the spec is kept for historical context.

--- a/docs/roadmap/session-persistence.md
+++ b/docs/roadmap/session-persistence.md
@@ -1,0 +1,193 @@
+# Session Persistence: Restore Parallel Chat Sessions on Launch
+
+Status: Planned (Phase 1 spec'd, not started)
+
+## Problem
+
+The extension renders each AI provider as an `<iframe>` in a panel. On every
+launch the iframe `src` is set to the provider's home URL
+([useProviderFramesController.ts#L254](../../src/multi-panel/hooks/useProviderFramesController.ts#L254)
+via [getPanelUrl](../../src/multi-panel/lib/panel-layout.ts#L56)), which is a
+fresh chat. So when Chrome restores the extension tab after a restart, every
+panel boots to a blank conversation. A user juggling several topics across
+several tabs loses all of them and has to manually navigate each provider's
+history back to where they were.
+
+Chrome does restore the tab, but only the top-level tab URL
+(`multi-panel/index.html`). It does not restore iframe navigation state, so the
+per-provider conversation URLs are state Chrome discards on reload. The app
+already captures those live URLs (content script -> `PARALLEL_AI_PROVIDER_URL`
+-> [useProviderUrlTracker](../../src/multi-panel/hooks/useProviderUrlTracker.ts))
+but currently throws them away instead of restoring them.
+
+## Goal
+
+When a workspace tab is reloaded by the browser (Chrome restart, F5, extension
+update) or reopened (Ctrl+Shift+T), every panel returns to exactly the
+conversation it was last showing, independently per tab. An intentional new
+open starts fresh.
+
+### Non-goals (Phase 1)
+
+- Named, switchable "topics" with their own UI (see Phase 2).
+- Restoring conversations a provider itself does not keep server-side.
+- Working while logged out of a provider (the iframe will show that provider's
+  login screen, same as today).
+
+## Approach: the tab URL is the source of truth
+
+Rather than maintain a separate persisted store, the workspace state is encoded
+into the tab's own URL via `history.replaceState`. This is where Chrome already
+keeps tab state, so restore and reopen "just work" with no side storage.
+
+Why this over `chrome.storage`:
+
+- Chrome session restore and Ctrl+Shift+T both restore the tab URL verbatim,
+  including its query string, so the encoded state rides along automatically.
+- A workspace's lifetime equals its tab's lifetime: open, closed, reopened.
+  That is exactly the Chrome-tab behavior requested.
+- No store to bound, garbage-collect, or grow. No storage quota concern and no
+  added permissions (no `unlimitedStorage`).
+- Per-tab independence is automatic, since each tab carries its own URL.
+
+Trade-off accepted: conversation ids end up in the tab URL and session history.
+They are opaque ids, useless without the user's provider login, but more visible
+than a side store.
+
+## Behavior: fresh vs restore
+
+The only signal needed is whether the loaded URL carries the state param.
+
+| Trigger | URL loaded | Result |
+| --- | --- | --- |
+| Toolbar click / Ctrl+Shift+E | `index.html` (bare) | Fresh |
+| Right-click "Pre-fill" / first install | `index.html` (bare) | Fresh |
+| Chrome restored the tab on restart | `index.html?s=...` | Restore |
+| F5 / manual reload / extension update | `index.html?s=...` | Restore |
+| Ctrl+Shift+T (reopen closed tab) | `index.html?s=...` | Restore |
+
+This requires no service-worker change: `openMultiPanel()`
+([background/service-worker.js#L9](../../background/service-worker.js#L9))
+already opens a bare URL, which now simply means "fresh."
+
+## Data model
+
+Encoded as `?s=<base64url(JSON)>` in the tab URL:
+
+```ts
+interface WorkspaceState {
+  v: 1;                                      // schema version
+  layout: LayoutId;                          // panel layout
+  panels: PanelProviderSlot[];               // which provider sits in which slot
+  urls: Partial<Record<ProviderId, string>>; // conversation URL per provider
+}
+```
+
+The URL carries the full workspace (layout + slot arrangement + conversation
+URLs), so each restored tab rebuilds itself completely and is independent of the
+global `panelProviders` / `currentLayout` settings. Those global settings become
+the default only for a brand-new fresh tab. Roughly 1 KB encoded, far under any
+URL limit.
+
+Excluded from encode and restore:
+
+- Temporary chats, detected **per-panel from the URL** (ChatGPT `?temporary-chat=true`,
+  Claude `?incognito`, Grok `#private`) rather than the global temp toggle — so a
+  temp-capable provider the user switched back to a regular chat is still saved.
+  Gemini/Qwen temp chats are not URL-distinguishable but sit at base URLs that
+  restore to a fresh chat anyway.
+- The Google panel (search, not a stable conversation).
+
+## Design decisions (resolved)
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Scope | Phase it: resume now, named topics later | Smallest change that kills the pain; topics layer on later. |
+| Launch behavior | Silent auto-restore, always on (no user setting); intentional opens are fresh | Matches Chrome tab restore; New Chat / a fresh open are the explicit reset, so a toggle is redundant. |
+| Storage location | The tab URL (no separate store) | Most faithful to "behave like a Chrome tab"; removes cap/GC/quota entirely. |
+| Per-tab vs global | Per-tab | User keeps multiple tabs open and relies on Chrome restoring them all. |
+| URL scope | Full workspace (layout + providers + conversations) | True per-tab independence even when tabs differ in provider composition. |
+| `unlimitedStorage` | Not added | No store to overflow; keep the permission set lean. |
+
+## Implementation plan
+
+### New files
+
+1. `src/multi-panel/lib/workspace-state.ts` — pure `encodeWorkspaceState` /
+   `decodeWorkspaceState` plus strict validation. Decode rejects malformed input
+   and, per URL, requires https and a host in a provider allowlist built from
+   [PROVIDERS](../../src/shared/lib/providers.ts), reusing
+   [sanitizeUrl](../../src/shared/lib/url-validator.ts#L14). Layout/panels are
+   validated with the existing `isLayoutId` / `isProviderId`. Also exports
+   `readWorkspaceParam(search)` and `getInitialWorkspaceState()` (reads
+   `window.location` synchronously at mount so the iframe's first `src` is the
+   restored URL, with no flash-then-reload).
+
+2. `src/multi-panel/hooks/useWorkspaceUrlController.ts` — exposes the parsed
+   `restoredState` (once, at mount) and a debounced (~600 ms) effect that
+   `history.replaceState`s the current `{ layout, panels, urls }`. Uses
+   `replaceState` (not push) so the back button is untouched. The encoded `urls`
+   is the restored baseline merged under live `urlByProvider`, so the URL never
+   regresses below what was restored before iframes finish reporting. Persists
+   unconditionally once hydrated (resume is always on; there is no toggle).
+
+### Changed files
+
+1. [App.tsx](../../src/multi-panel/App.tsx) — read `getInitialWorkspaceState()`
+   once; at the hydration effect, when a restored state exists pass its
+   `layout` / `panels` to `hydratePanelLayout` instead of the settings values;
+   pass `restoredState.urls` into the frames controller; add the persistence hook
+   fed by `layout`, `panelProviders`, and `urlByProvider`.
+
+2. [usePanelLayoutController.ts](../../src/multi-panel/hooks/usePanelLayoutController.ts)
+   — accept an `isRestoredTab` flag and skip the two passive effects that mirror
+   `currentLayout` / `panelProviders` into global settings when set. A restored
+   tab's layout/panels are per-tab state (in its `?s=`) and must not overwrite
+   the global fresh-tab default. App passes a stable `isRestoredTab` (whether the
+   tab had restorable state at hydration) that also gates the frame-restore
+   source.
+
+3. [useProviderFramesController.ts](../../src/multi-panel/hooks/useProviderFramesController.ts)
+   — accept `restoredUrlByProvider` and a resume flag. Add
+   `computeIntendedSrc(provider)`: on a frame's first creation use the restored
+   URL (when present and not temp), else `getPanelUrl`; on later renders keep the
+   current src so it never reloads to home; reload only when a genuine trigger
+   fires (temp toggle, Google mode change, manual refresh, detected via the
+   existing `getPanelUrl` output plus the refresh key). Replace the
+   `getPanelUrl(...)` call at
+   [#L254](../../src/multi-panel/hooks/useProviderFramesController.ts#L254) with
+   this, and clear the new refs in the existing teardown.
+
+### Deliberately unchanged
+
+- `manifest.json` — no new permission; the guardrail test does not pin the
+  permissions array, so nothing breaks.
+- `background/service-worker.js` — bare-URL opens already mean "fresh."
+
+## Tests
+
+- `tests/unit/workspace-state.test.ts` — encode/decode roundtrip, version
+  gating, rejects malformed / non-https / non-provider-host URLs, drops
+  temp/Google.
+- Extend
+  [tests/hooks/useProviderFramesController.test.ts](../../tests/hooks/useProviderFramesController.test.ts)
+  — seeds the restored URL exactly once; no home-reload on re-render; reloads on
+  temp toggle / Google mode / manual refresh.
+- New persistence-hook test — debounced `replaceState`, restored-baseline merge,
+  and exclusions.
+
+## Known trade-offs and limitations
+
+- Conversation ids live in the tab URL and session history (opaque, login-gated,
+  but more visible than a side store).
+- Manual refresh on a panel reloads to home/new chat (current semantics), which
+  drops that panel's restored conversation. Improvable later; out of scope here.
+- The seeding-without-reload logic in the frames controller is the one delicate
+  piece and is what the tests pin down.
+
+## Phase 2 (out of scope here)
+
+Named, switchable topics with their own UI. This adds a lightweight storage index
+that mirrors workspaces so topics can be listed across tabs and closed tabs. The
+tab URL stays the restore mechanism; the index is only for listing/switching. No
+migration needed: it layers on the same `WorkspaceState` shape.

--- a/docs/roadmap/session-persistence.md
+++ b/docs/roadmap/session-persistence.md
@@ -1,6 +1,6 @@
 # Session Persistence: Restore Parallel Chat Sessions on Launch
 
-Status: Planned (Phase 1 spec'd, not started)
+Status: Shipped in v1.0.3. The spec below is kept for historical context.
 
 ## Problem
 

--- a/src/multi-panel/App.tsx
+++ b/src/multi-panel/App.tsx
@@ -28,6 +28,7 @@ import { useProviderActionsController } from "@/multi-panel/hooks/useProviderAct
 import { useProviderFramesController } from "@/multi-panel/hooks/useProviderFramesController";
 import { useProviderTitleTracker } from "@/multi-panel/hooks/useProviderTitleTracker";
 import { useProviderUrlTracker } from "@/multi-panel/hooks/useProviderUrlTracker";
+import { useWorkspaceUrlController } from "@/multi-panel/hooks/useWorkspaceUrlController";
 import { useVersionCheck } from "@/multi-panel/hooks/useVersionCheck";
 import { useWorkspaceDataController } from "@/multi-panel/hooks/useWorkspaceDataController";
 import { useProviderContext } from "@/shared/contexts/ProviderContext";
@@ -39,6 +40,8 @@ import {
   resizePanelProviders,
 } from "@/multi-panel/lib/panel-layout";
 import { runtimeAsset } from "@/multi-panel/lib/runtime";
+import { getInitialWorkspaceState } from "@/multi-panel/lib/workspace-state";
+import { resolveWorkspaceTitle } from "@/multi-panel/lib/workspace-title";
 import { DEFAULT_LAYOUT } from "@/shared/lib/layouts";
 import { DEFAULT_PANEL_PROVIDERS } from "@/shared/lib/constants";
 import { DEFAULT_FOCUS_MODAL_WIDTH } from "@/shared/lib/settings";
@@ -70,6 +73,12 @@ export function App() {
   const [temporaryChatEnabled, setTemporaryChatEnabled] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("appearance");
   const [focusedSlotIndex, setFocusedSlotIndex] = useState<number | null>(null);
+  // Parsed once at mount from the tab URL (?s=); drives launch-time restore.
+  const [restoredWorkspace] = useState(() => getInitialWorkspaceState());
+  // Whether restore was applied at hydration. Stable for the tab's lifetime so a
+  // later resume toggle can't retroactively restore, and so a restored tab never
+  // mirrors its per-tab layout/panels into the global (fresh-tab) defaults.
+  const [isRestoredTab, setIsRestoredTab] = useState(false);
 
   const statusTimeoutRef = useRef<number | null>(null);
   const frameRefs = useRef<Record<string, HTMLIFrameElement | null>>({});
@@ -206,6 +215,7 @@ export function App() {
   } = usePanelLayoutController({
     enabledProviders: settings.enabledProviders,
     isHydrated,
+    isRestoredTab,
     showStatus,
     updateSetting,
   });
@@ -249,6 +259,8 @@ export function App() {
     queueConnectorLayoutRefresh,
     resolvedTheme,
     temporaryChatEnabled,
+    restoredUrlByProvider: restoredWorkspace?.urls,
+    resumeEnabled: isRestoredTab,
   });
   const {
     clearPanels,
@@ -285,6 +297,14 @@ export function App() {
   const { urlByProvider } = useProviderUrlTracker({ frameRefs });
   const { titleByProvider } = useProviderTitleTracker({ frameRefs });
 
+  useWorkspaceUrlController({
+    isHydrated,
+    layout,
+    panelProviders,
+    urlByProvider,
+    baselineUrls: restoredWorkspace?.urls ?? {},
+  });
+
   const onboardingTour = useOnboardingTour({
     ready: loaded && isHydrated,
     context: {
@@ -298,20 +318,8 @@ export function App() {
   });
 
   useEffect(() => {
-    const leftmostProvider = panelProviders.find((id): id is ProviderId => Boolean(id));
-    if (!leftmostProvider) {
-      document.title = "Parallel AI";
-      return;
-    }
-    const entry = titleByProvider[leftmostProvider];
-    const title = entry?.title.trim() ?? "";
-    const initialTitle = entry?.initialTitle.trim() ?? "";
-    if (!title || title === initialTitle) {
-      document.title = "Parallel AI";
-      return;
-    }
-    document.title = title;
-  }, [panelProviders, titleByProvider]);
+    document.title = resolveWorkspaceTitle(panelProviders, titleByProvider, temporaryChatEnabled);
+  }, [panelProviders, titleByProvider, temporaryChatEnabled]);
 
   useEffect(() => {
     if (focusedSlotIndex === null) {
@@ -377,13 +385,19 @@ export function App() {
       return;
     }
 
-    hydratePanelLayout(settings.currentLayout, settings.panelProviders, settings.enabledProviders);
+    setIsRestoredTab(Boolean(restoredWorkspace));
+    hydratePanelLayout(
+      restoredWorkspace?.layout ?? settings.currentLayout,
+      restoredWorkspace?.panels ?? settings.panelProviders,
+      settings.enabledProviders,
+    );
     hydrateComposerFrame();
     setIsHydrated(true);
   }, [
     hydrateComposerFrame,
     isHydrated,
     loaded,
+    restoredWorkspace,
     settings.composerSize,
     settings.currentLayout,
     settings.enabledProviders,

--- a/src/multi-panel/hooks/usePanelLayoutController.ts
+++ b/src/multi-panel/hooks/usePanelLayoutController.ts
@@ -24,6 +24,9 @@ import {
 interface UsePanelLayoutControllerOptions {
   enabledProviders: ProviderId[];
   isHydrated: boolean;
+  // When this tab was restored from its URL, its layout/panels are per-tab state
+  // and must NOT be mirrored back into the global (fresh-tab default) settings.
+  isRestoredTab?: boolean;
   showStatus: (message: string) => void;
   updateSetting: <Key extends keyof ExtensionSettings>(
     key: Key,
@@ -34,6 +37,7 @@ interface UsePanelLayoutControllerOptions {
 export function usePanelLayoutController({
   enabledProviders,
   isHydrated,
+  isRestoredTab = false,
   showStatus,
   updateSetting,
 }: UsePanelLayoutControllerOptions) {
@@ -81,20 +85,20 @@ export function usePanelLayoutController({
   }, [enabledProviders, isHydrated, layout, panelProviders]);
 
   useEffect(() => {
-    if (!isHydrated) {
+    if (!isHydrated || isRestoredTab) {
       return;
     }
 
     void updateSetting("currentLayout", layout);
-  }, [isHydrated, layout, updateSetting]);
+  }, [isHydrated, isRestoredTab, layout, updateSetting]);
 
   useEffect(() => {
-    if (!isHydrated) {
+    if (!isHydrated || isRestoredTab) {
       return;
     }
 
     void updateSetting("panelProviders", panelProviders);
-  }, [isHydrated, panelProviders, updateSetting]);
+  }, [isHydrated, isRestoredTab, panelProviders, updateSetting]);
 
   useEffect(() => {
     return () => {

--- a/src/multi-panel/hooks/useProviderActionsController.ts
+++ b/src/multi-panel/hooks/useProviderActionsController.ts
@@ -1,6 +1,9 @@
 import type { Dispatch, SetStateAction } from "react";
 
-import { TEMP_CHAT_SUPPORTED_PROVIDERS } from "@/shared/lib/constants";
+import {
+  DOM_TEMP_CHAT_PROVIDERS,
+  TEMP_CHAT_SUPPORTED_PROVIDERS,
+} from "@/shared/lib/constants";
 import { tx } from "@/shared/lib/i18n";
 import type { ProviderId } from "@/shared/lib/providers";
 import type { PanelProviderSlot } from "@/shared/lib/settings";
@@ -188,6 +191,18 @@ export function useProviderActionsController({
         if (TEMP_CHAT_SUPPORTED_PROVIDERS.has(providerId)) {
           postToProvider(providerId, {
             type: "ENABLE_TEMP_CHAT",
+          });
+        }
+      }
+    } else {
+      // URL-based providers (ChatGPT/Claude/Grok) return to normal chat by
+      // reloading the iframe to their normal URL. Providers whose temp and
+      // normal URLs are identical (Gemini/Qwen) never reload, so explicitly
+      // ask their content script to click the temp toggle back off.
+      for (const providerId of getActivePanelProviders(panelProviders)) {
+        if (DOM_TEMP_CHAT_PROVIDERS.has(providerId)) {
+          postToProvider(providerId, {
+            type: "DISABLE_TEMP_CHAT",
           });
         }
       }

--- a/src/multi-panel/hooks/useProviderFramesController.ts
+++ b/src/multi-panel/hooks/useProviderFramesController.ts
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState, type MutableRefObject } from "react";
 
 import { TEMP_CHAT_SUPPORTED_PROVIDERS } from "@/shared/lib/constants";
-import { getProviderById, type ProviderId } from "@/shared/lib/providers";
+import { getProviderById, type Provider, type ProviderId } from "@/shared/lib/providers";
 import type { GoogleProviderMode, PanelProviderSlot } from "@/shared/lib/settings";
 import type { ResolvedTheme } from "@/shared/lib/theme";
 import { getActivePanelProviders, getPanelUrl } from "@/multi-panel/lib/panel-layout";
+
+const EMPTY_RESTORED_URLS: Partial<Record<ProviderId, string>> = {};
 
 interface UseProviderFramesControllerOptions {
   frameRefs: MutableRefObject<Record<string, HTMLIFrameElement | null>>;
@@ -15,6 +17,10 @@ interface UseProviderFramesControllerOptions {
   queueConnectorLayoutRefresh: () => void;
   resolvedTheme: ResolvedTheme;
   temporaryChatEnabled: boolean;
+  // Conversation URLs restored from this tab's launch state. Used to seed a
+  // panel's first iframe src instead of the provider home page.
+  restoredUrlByProvider?: Partial<Record<ProviderId, string>>;
+  resumeEnabled?: boolean;
 }
 
 export function useProviderFramesController({
@@ -26,12 +32,20 @@ export function useProviderFramesController({
   queueConnectorLayoutRefresh,
   resolvedTheme,
   temporaryChatEnabled,
+  restoredUrlByProvider = EMPTY_RESTORED_URLS,
+  resumeEnabled = false,
 }: UseProviderFramesControllerOptions) {
   const [loadingProviders, setLoadingProviders] = useState<Record<string, boolean>>({});
   const [refreshByProvider, setRefreshByProvider] = useState<Record<string, number>>({});
   const frameHostRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const frameDescriptorRefs = useRef<Record<string, string>>({});
   const previousPanelProvidersRef = useRef<PanelProviderSlot[]>(panelProviders);
+  // Per-provider "intended" src so a panel never silently reloads to home once
+  // it has been created. The restored URL only wins at first creation; genuine
+  // reload triggers (temp/Google/refresh) move it to the normal URL.
+  const intendedSrcRef = useRef<Partial<Record<ProviderId, string>>>({});
+  const reloadKeyRef = useRef<Partial<Record<ProviderId, string>>>({});
+  const restoreConsumedRef = useRef<Set<ProviderId>>(new Set());
 
   function postToProvider(
     providerId: ProviderId,
@@ -88,6 +102,36 @@ export function useProviderFramesController({
     }
   }
 
+  function computeIntendedSrc(provider: Provider): string {
+    const normalSrc = getPanelUrl(provider, googleProviderMode, temporaryChatEnabled);
+    const reloadKey = `${normalSrc}|${refreshByProvider[provider.id] ?? 0}`;
+    const existing = intendedSrcRef.current[provider.id];
+
+    if (existing === undefined) {
+      const tempActive =
+        temporaryChatEnabled && TEMP_CHAT_SUPPORTED_PROVIDERS.has(provider.id);
+      const canRestore =
+        resumeEnabled && !tempActive && !restoreConsumedRef.current.has(provider.id);
+      const restored = canRestore ? restoredUrlByProvider[provider.id] : undefined;
+      restoreConsumedRef.current.add(provider.id);
+
+      const chosen = restored ?? normalSrc;
+      intendedSrcRef.current[provider.id] = chosen;
+      reloadKeyRef.current[provider.id] = reloadKey;
+      return chosen;
+    }
+
+    if (reloadKeyRef.current[provider.id] !== reloadKey) {
+      // A genuine reload trigger fired (temp toggle, Google mode, manual
+      // refresh): abandon any restored URL and load the normal/new-chat URL.
+      intendedSrcRef.current[provider.id] = normalSrc;
+      reloadKeyRef.current[provider.id] = reloadKey;
+      return normalSrc;
+    }
+
+    return existing;
+  }
+
   function ensureProviderFrame(providerId: ProviderId, src: string, title: string) {
     const descriptor = `${src}|${refreshByProvider[providerId] ?? 0}`;
     let frame = frameRefs.current[providerId];
@@ -129,17 +173,24 @@ export function useProviderFramesController({
 
   function registerFrameHost(
     providerId: ProviderId,
-    src: string,
+    _src: string,
     title: string,
     element: HTMLDivElement | null,
   ) {
     frameHostRefs.current[providerId] = element;
 
-    if (!element) {
+    if (!element || !isHydrated) {
+      // Pre-hydration hosts are attached by the post-hydration effect below, so
+      // the restore decision always runs once settings are loaded.
       return;
     }
 
-    ensureProviderFrame(providerId, src, title);
+    const provider = getProviderById(providerId);
+    if (!provider) {
+      return;
+    }
+
+    ensureProviderFrame(providerId, computeIntendedSrc(provider), title);
   }
 
   function refreshProvider(providerId: ProviderId) {
@@ -249,11 +300,7 @@ export function useProviderFramesController({
         return;
       }
 
-      ensureProviderFrame(
-        providerId,
-        getPanelUrl(provider, googleProviderMode, temporaryChatEnabled),
-        provider.name,
-      );
+      ensureProviderFrame(providerId, computeIntendedSrc(provider), provider.name);
     });
 
     Object.keys(frameRefs.current).forEach((providerId) => {

--- a/src/multi-panel/hooks/useWorkspaceUrlController.ts
+++ b/src/multi-panel/hooks/useWorkspaceUrlController.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react";
+
+import type { LayoutId } from "@/shared/lib/layouts";
+import type { ProviderId } from "@/shared/lib/providers";
+import type { PanelProviderSlot } from "@/shared/lib/settings";
+import { getActivePanelProviders } from "@/multi-panel/lib/panel-layout";
+import {
+  WORKSPACE_STATE_VERSION,
+  buildWorkspaceUrl,
+  isRestorableProviderUrl,
+  isTemporaryChatUrl,
+  type WorkspaceState,
+} from "@/multi-panel/lib/workspace-state";
+
+const PERSIST_DEBOUNCE_MS = 600;
+
+interface UseWorkspaceUrlControllerOptions {
+  isHydrated: boolean;
+  layout: LayoutId;
+  panelProviders: PanelProviderSlot[];
+  // Live conversation URLs reported by each provider iframe.
+  urlByProvider: Record<string, string>;
+  // Restored URLs from this tab's launch, used as a floor so the encoded state
+  // never regresses below what was restored before iframes report live URLs.
+  baselineUrls: Partial<Record<ProviderId, string>>;
+}
+
+export function useWorkspaceUrlController({
+  isHydrated,
+  layout,
+  panelProviders,
+  urlByProvider,
+  baselineUrls,
+}: UseWorkspaceUrlControllerOptions) {
+  const baselineRef = useRef(baselineUrls);
+
+  useEffect(() => {
+    if (!isHydrated) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const urls: Partial<Record<ProviderId, string>> = {};
+
+      for (const providerId of getActivePanelProviders(panelProviders)) {
+        const candidate = urlByProvider[providerId] ?? baselineRef.current[providerId];
+        // Skip ephemeral temporary chats. Detected per-panel from the URL (not
+        // the global temp toggle), so a temp-capable provider that was switched
+        // back to a regular chat is still saved.
+        if (!candidate || isTemporaryChatUrl(providerId, candidate)) {
+          continue;
+        }
+        if (isRestorableProviderUrl(providerId, candidate)) {
+          urls[providerId] = candidate;
+        }
+      }
+
+      const state: WorkspaceState = {
+        v: WORKSPACE_STATE_VERSION,
+        layout,
+        panels: panelProviders,
+        urls,
+      };
+      replaceWorkspaceUrl(state);
+    }, PERSIST_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [isHydrated, layout, panelProviders, urlByProvider]);
+}
+
+function replaceWorkspaceUrl(state: WorkspaceState | null) {
+  if (typeof window === "undefined" || !window.history?.replaceState) {
+    return;
+  }
+
+  const nextUrl = buildWorkspaceUrl(
+    { pathname: window.location.pathname, search: window.location.search },
+    state,
+  );
+  // replaceState (not push) so the back button is untouched.
+  window.history.replaceState(window.history.state, "", nextUrl);
+}

--- a/src/multi-panel/hooks/useWorkspaceUrlController.ts
+++ b/src/multi-panel/hooks/useWorkspaceUrlController.ts
@@ -40,9 +40,17 @@ export function useWorkspaceUrlController({
     }
 
     const timer = window.setTimeout(() => {
+      const activeProviders = getActivePanelProviders(panelProviders);
+      if (activeProviders.length === 0) {
+        // No restorable panels — clear any stale ?s= rather than writing a state
+        // that decodeWorkspaceState would reject anyway.
+        replaceWorkspaceUrl(null);
+        return;
+      }
+
       const urls: Partial<Record<ProviderId, string>> = {};
 
-      for (const providerId of getActivePanelProviders(panelProviders)) {
+      for (const providerId of activeProviders) {
         const candidate = urlByProvider[providerId] ?? baselineRef.current[providerId];
         // Skip ephemeral temporary chats. Detected per-panel from the URL (not
         // the global temp toggle), so a temp-capable provider that was switched

--- a/src/multi-panel/lib/workspace-state.ts
+++ b/src/multi-panel/lib/workspace-state.ts
@@ -133,7 +133,13 @@ function normalizeUrls(value: unknown): Partial<Record<ProviderId, string>> {
   }
 
   for (const [key, candidate] of Object.entries(value as Record<string, unknown>)) {
-    if (isProviderId(key) && isRestorableProviderUrl(key, candidate)) {
+    // Mirror the write path: reject temp-chat URLs so a crafted ?s= can't load a
+    // panel into a temporary chat while the global toggle reads off.
+    if (
+      isProviderId(key) &&
+      isRestorableProviderUrl(key, candidate) &&
+      !isTemporaryChatUrl(key, candidate)
+    ) {
       urls[key] = candidate;
     }
   }

--- a/src/multi-panel/lib/workspace-state.ts
+++ b/src/multi-panel/lib/workspace-state.ts
@@ -1,0 +1,213 @@
+import { isLayoutId, type LayoutId } from "@/shared/lib/layouts";
+import { isProviderId, type ProviderId } from "@/shared/lib/providers";
+import type { PanelProviderSlot } from "@/shared/lib/settings";
+
+// The workspace state is encoded into the tab URL (?s=<base64url(json)>) so the
+// browser restores it for free on session restore / reload / reopen-closed-tab.
+// See docs/roadmap/session-persistence.md.
+export const WORKSPACE_STATE_PARAM = "s";
+export const WORKSPACE_STATE_VERSION = 1 as const;
+
+export interface WorkspaceState {
+  v: typeof WORKSPACE_STATE_VERSION;
+  layout: LayoutId;
+  panels: PanelProviderSlot[];
+  urls: Partial<Record<ProviderId, string>>;
+}
+
+// Hosts each provider's conversation URLs may legitimately use. Mirrors the
+// manifest host_permissions. Restoring an iframe src to anything else is
+// rejected so a crafted ?s= cannot point a panel at an arbitrary origin.
+const PROVIDER_HOSTS: Record<ProviderId, readonly string[]> = {
+  chatgpt: ["chatgpt.com", "chat.openai.com"],
+  claude: ["claude.ai"],
+  gemini: ["gemini.google.com"],
+  grok: ["grok.com"],
+  deepseek: ["chat.deepseek.com"],
+  kimi: ["kimi.com", "www.kimi.com"],
+  qwen: ["chat.qwen.ai"],
+  meta: ["meta.ai", "www.meta.ai"],
+  google: ["google.com", "www.google.com"],
+};
+
+// Google is search, not a resumable conversation, so it is never restored.
+const NON_RESTORABLE_PROVIDERS = new Set<ProviderId>(["google"]);
+
+export function isRestorableProviderUrl(
+  providerId: ProviderId,
+  url: unknown,
+): url is string {
+  if (typeof url !== "string" || NON_RESTORABLE_PROVIDERS.has(providerId)) {
+    return false;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  return parsed.protocol === "https:" && PROVIDER_HOSTS[providerId].includes(parsed.hostname);
+}
+
+/**
+ * Detects a per-panel temporary chat from its URL. Temp chats are ephemeral (no
+ * restorable history) and are excluded from the saved workspace. This is
+ * URL-based, NOT the global temp toggle, so a temp-capable provider the user
+ * switched back to a regular chat is still saved. Mirrors the content script's
+ * isTemporaryChatAlreadyEnabled URL checks. Providers whose temp chats are not
+ * URL-distinguishable (gemini, qwen) are never matched here; their ephemeral
+ * chats sit at base URLs that restore to a fresh chat anyway.
+ */
+export function isTemporaryChatUrl(providerId: ProviderId, url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  switch (providerId) {
+    case "chatgpt":
+      return parsed.searchParams.get("temporary-chat") === "true";
+    case "claude":
+      return parsed.searchParams.has("incognito");
+    case "grok":
+      return parsed.hash === "#private";
+    default:
+      return false;
+  }
+}
+
+function base64UrlEncode(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded =
+    normalized.length % 4 === 0
+      ? normalized
+      : normalized + "=".repeat(4 - (normalized.length % 4));
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function normalizePanels(value: unknown): PanelProviderSlot[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seen = new Set<ProviderId>();
+  const panels: PanelProviderSlot[] = [];
+
+  for (const entry of value) {
+    if (typeof entry === "string" && isProviderId(entry) && !seen.has(entry)) {
+      seen.add(entry);
+      panels.push(entry);
+    } else {
+      // Preserve slot positions for empty / unknown entries.
+      panels.push(null);
+    }
+  }
+
+  while (panels.length > 0 && panels[panels.length - 1] === null) {
+    panels.pop();
+  }
+
+  return panels;
+}
+
+function normalizeUrls(value: unknown): Partial<Record<ProviderId, string>> {
+  const urls: Partial<Record<ProviderId, string>> = {};
+
+  if (!value || typeof value !== "object") {
+    return urls;
+  }
+
+  for (const [key, candidate] of Object.entries(value as Record<string, unknown>)) {
+    if (isProviderId(key) && isRestorableProviderUrl(key, candidate)) {
+      urls[key] = candidate;
+    }
+  }
+
+  return urls;
+}
+
+export function encodeWorkspaceState(state: WorkspaceState): string {
+  return base64UrlEncode(JSON.stringify(state));
+}
+
+export function decodeWorkspaceState(param: string | null | undefined): WorkspaceState | null {
+  if (!param) {
+    return null;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(base64UrlDecode(param));
+  } catch {
+    return null;
+  }
+
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+
+  const candidate = raw as Record<string, unknown>;
+  if (candidate.v !== WORKSPACE_STATE_VERSION) {
+    return null;
+  }
+
+  if (typeof candidate.layout !== "string" || !isLayoutId(candidate.layout)) {
+    return null;
+  }
+
+  const panels = normalizePanels(candidate.panels);
+  if (!panels.some(Boolean)) {
+    return null;
+  }
+
+  return {
+    v: WORKSPACE_STATE_VERSION,
+    layout: candidate.layout,
+    panels,
+    urls: normalizeUrls(candidate.urls),
+  };
+}
+
+export function readWorkspaceParam(search: string): string | null {
+  try {
+    return new URLSearchParams(search).get(WORKSPACE_STATE_PARAM);
+  } catch {
+    return null;
+  }
+}
+
+export function getInitialWorkspaceState(): WorkspaceState | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return decodeWorkspaceState(readWorkspaceParam(window.location.search));
+}
+
+export function buildWorkspaceUrl(
+  location: { pathname: string; search: string },
+  state: WorkspaceState | null,
+): string {
+  const params = new URLSearchParams(location.search);
+  if (state) {
+    params.set(WORKSPACE_STATE_PARAM, encodeWorkspaceState(state));
+  } else {
+    params.delete(WORKSPACE_STATE_PARAM);
+  }
+  const query = params.toString();
+  return query ? `${location.pathname}?${query}` : location.pathname;
+}

--- a/src/multi-panel/lib/workspace-title.ts
+++ b/src/multi-panel/lib/workspace-title.ts
@@ -1,0 +1,52 @@
+import { TEMP_CHAT_SUPPORTED_PROVIDERS } from "@/shared/lib/constants";
+import type { PanelProviderSlot } from "@/shared/lib/settings";
+import { getActivePanelProviders } from "@/multi-panel/lib/panel-layout";
+
+export const DEFAULT_DOCUMENT_TITLE = "Parallel AI";
+export const TEMPORARY_DOCUMENT_TITLE = "Temporary Chats";
+
+interface ProviderTitleEntry {
+  title: string;
+  initialTitle: string;
+}
+
+/**
+ * Decides the browser tab title for the workspace.
+ *
+ * The workspace reads as temporary ("Temporary Chats") only when EVERY panel is
+ * a temporary chat. A mix of temp + regular panels is a regular, restorable
+ * workspace: on restore the temp panels come back as new chats while the regular
+ * panels reopen their conversations, so it keeps the regular title.
+ *
+ * A panel is a temporary chat only when temp mode is on AND that provider
+ * supports it (ChatGPT, Claude, Gemini, Grok, Qwen).
+ */
+export function resolveWorkspaceTitle(
+  panelProviders: PanelProviderSlot[],
+  titleByProvider: Record<string, ProviderTitleEntry | undefined>,
+  temporaryChatEnabled: boolean,
+): string {
+  const activeProviders = getActivePanelProviders(panelProviders);
+
+  const allTemporary =
+    temporaryChatEnabled &&
+    activeProviders.length > 0 &&
+    activeProviders.every((id) => TEMP_CHAT_SUPPORTED_PROVIDERS.has(id));
+  if (allTemporary) {
+    return TEMPORARY_DOCUMENT_TITLE;
+  }
+
+  const firstProvider = activeProviders[0];
+  if (!firstProvider) {
+    return DEFAULT_DOCUMENT_TITLE;
+  }
+
+  const entry = titleByProvider[firstProvider];
+  const title = entry?.title.trim() ?? "";
+  const initialTitle = entry?.initialTitle.trim() ?? "";
+  if (!title || title === initialTitle) {
+    return DEFAULT_DOCUMENT_TITLE;
+  }
+
+  return title;
+}

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -27,4 +27,14 @@ export const NORMAL_URLS: Partial<Record<ProviderId, string>> = {
   grok: "https://grok.com/",
 };
 
+// Providers whose temporary and normal chat URLs are identical (e.g. Gemini and
+// Qwen, which fall back to the same provider URL). For these, temp mode is an
+// in-page DOM toggle rather than a URL the iframe can reload to, so switching it
+// off requires an explicit DISABLE_TEMP_CHAT click rather than a frame reload.
+export const DOM_TEMP_CHAT_PROVIDERS = new Set<ProviderId>(
+  [...TEMP_CHAT_SUPPORTED_PROVIDERS].filter(
+    (id) => (TEMP_CHAT_URLS[id] ?? null) === (NORMAL_URLS[id] ?? null),
+  ),
+);
+
 export const PENDING_MULTI_PANEL_ACTION_KEY = "pendingMultiPanelAction";

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -27,14 +27,14 @@ export const NORMAL_URLS: Partial<Record<ProviderId, string>> = {
   grok: "https://grok.com/",
 };
 
-// Providers whose temporary and normal chat URLs are identical (e.g. Gemini and
-// Qwen, which fall back to the same provider URL). For these, temp mode is an
-// in-page DOM toggle rather than a URL the iframe can reload to, so switching it
-// off requires an explicit DISABLE_TEMP_CHAT click rather than a frame reload.
+// Providers that toggle temporary chat in-page (a DOM click) rather than via a
+// distinct URL the iframe can reload to. This holds when a provider has no
+// temp-chat URL that differs from its normal one: gemini's temp and normal URLs
+// are identical, and qwen has no entry in either map at all (undefined ===
+// undefined). For these, leaving temp mode needs an explicit DISABLE_TEMP_CHAT
+// click instead of a frame reload.
 export const DOM_TEMP_CHAT_PROVIDERS = new Set<ProviderId>(
-  [...TEMP_CHAT_SUPPORTED_PROVIDERS].filter(
-    (id) => (TEMP_CHAT_URLS[id] ?? null) === (NORMAL_URLS[id] ?? null),
-  ),
+  [...TEMP_CHAT_SUPPORTED_PROVIDERS].filter((id) => TEMP_CHAT_URLS[id] === NORMAL_URLS[id]),
 );
 
 export const PENDING_MULTI_PANEL_ACTION_KEY = "pendingMultiPanelAction";

--- a/tests/content-scripts/gemini-temp-chat.test.ts
+++ b/tests/content-scripts/gemini-temp-chat.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+function readContentScript(name: string): string {
+  return readFileSync(
+    path.resolve(process.cwd(), "content-scripts", name),
+    "utf8",
+  );
+}
+
+// Extract the two cooperating predicates from the text-injection IIFE and
+// evaluate them in isolation (the repo's standard eval-extraction approach).
+// Indentation is backreferenced so reformatting the source can't break it.
+function loadGeminiTempChatDetector(): (control?: Element | null) => boolean {
+  const src = readContentScript("text-injection-all-providers.js");
+
+  const active = src.match(
+    /\n([ \t]*)function isTemporaryChatControlActive\(element\) \{[\s\S]*?\n\1\}/,
+  );
+  const gemini = src.match(
+    /\n([ \t]*)function isGeminiTemporaryChatEnabled\(control = null\) \{[\s\S]*?\n\1\}/,
+  );
+
+  if (!active || !gemini) {
+    throw new Error("temp-chat detection functions not found in content script");
+  }
+
+  return new Function(
+    `${active[0]}\n${gemini[0]}\n; return isGeminiTemporaryChatEnabled;`,
+  )() as (control?: Element | null) => boolean;
+}
+
+// Build the live Gemini control shape:
+//   <temp-chat-button>
+//     <gem-icon-button data-test-id="temp-chat-button" class="temp-chat-button ...">
+//       <button aria-label="Temporary chat">
+// The "on" state is a `temp-chat-on` class on the <gem-icon-button> wrapper.
+function mountGeminiControl(enabled: boolean) {
+  document.body.innerHTML = "";
+  const custom = document.createElement("temp-chat-button");
+  const wrapper = document.createElement("gem-icon-button");
+  wrapper.setAttribute("data-test-id", "temp-chat-button");
+  wrapper.classList.add("temp-chat-button", "gem-button");
+  if (enabled) {
+    wrapper.classList.add("temp-chat-on");
+  }
+  const button = document.createElement("button");
+  button.setAttribute("aria-label", "Temporary chat");
+  wrapper.appendChild(button);
+  custom.appendChild(wrapper);
+  document.body.appendChild(custom);
+  return { wrapper, button };
+}
+
+describe("isGeminiTemporaryChatEnabled reads the live wrapper state", () => {
+  const isEnabled = loadGeminiTempChatDetector();
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns false when no control is present", () => {
+    document.body.innerHTML = "";
+    expect(isEnabled(null)).toBe(false);
+  });
+
+  it("returns false for a normal (off) chat", () => {
+    mountGeminiControl(false);
+    expect(isEnabled(null)).toBe(false);
+  });
+
+  it("detects the on state from the document when no control is passed", () => {
+    mountGeminiControl(true);
+    expect(isEnabled(null)).toBe(true);
+  });
+
+  it("detects the on state when given the inner <button> (closest wrapper)", () => {
+    const { button } = mountGeminiControl(true);
+    expect(isEnabled(button)).toBe(true);
+  });
+
+  it("detects the on state when given the <gem-icon-button> wrapper", () => {
+    const { wrapper } = mountGeminiControl(true);
+    expect(isEnabled(wrapper)).toBe(true);
+  });
+
+  it("does not report on when the inner button is passed but temp is off", () => {
+    const { button } = mountGeminiControl(false);
+    expect(isEnabled(button)).toBe(false);
+  });
+});

--- a/tests/e2e/fixtures/session-restore.spec.ts
+++ b/tests/e2e/fixtures/session-restore.spec.ts
@@ -1,0 +1,230 @@
+import { Buffer } from "node:buffer";
+
+import { expect, test } from "../_fixtures";
+import { stubProviderRequests } from "../helpers/provider-stub";
+
+function encodeWorkspaceState(state: unknown): string {
+  return Buffer.from(JSON.stringify(state)).toString("base64url");
+}
+
+function decodeSearch(search: string): { urls?: Record<string, string> } | null {
+  const s = new URLSearchParams(search).get("s");
+  if (!s) return null;
+  try {
+    return JSON.parse(Buffer.from(s, "base64url").toString());
+  } catch {
+    return null;
+  }
+}
+
+async function readFrameSrcs(page: import("@playwright/test").Page) {
+  return page.locator("iframe").evaluateAll((els) =>
+    (els as HTMLIFrameElement[]).map((el) => ({ title: el.title, src: el.src })),
+  );
+}
+
+test.describe("session restore", () => {
+  test("restores a regular panel's conversation while leaving a temp-capable sibling fresh", async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await stubProviderRequests(page);
+    await page.addInitScript(() => {
+      try {
+        chrome.storage?.local?.set({ onboardingState: { completedVersion: 9999 } });
+      } catch {
+        // ignore
+      }
+    });
+
+    const restoredUrl = "https://chat.deepseek.com/a/chat/s/RESTORED123";
+    const s = encodeWorkspaceState({
+      v: 1,
+      layout: "1x2",
+      panels: ["chatgpt", "deepseek"],
+      // chatgpt has no saved URL (would be a temp panel) -> fresh on restore.
+      // deepseek is a regular chat -> should reopen this conversation.
+      urls: { deepseek: restoredUrl },
+    });
+
+    await page.goto(`chrome-extension://${extensionId}/multi-panel/index.html?s=${s}`);
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+
+    // The regular panel reopens its conversation.
+    await expect
+      .poll(
+        async () => {
+          const frames = await readFrameSrcs(page);
+          return frames.find((f) => /deepseek/i.test(f.title))?.src ?? "";
+        },
+        { timeout: 10_000 },
+      )
+      .toContain("RESTORED123");
+
+    // The temp-capable sibling with no saved URL starts a fresh chat.
+    const frames = await readFrameSrcs(page);
+    const chatgpt = frames.find((f) => /chatgpt/i.test(f.title));
+    expect(chatgpt?.src ?? "").not.toContain("RESTORED");
+  });
+
+  test("saves a regular panel's conversation and reopens it after a reload", async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await stubProviderRequests(page);
+    await page.addInitScript(() => {
+      try {
+        chrome.storage?.local?.set({ onboardingState: { completedVersion: 9999 } });
+      } catch {
+        // ignore
+      }
+    });
+
+    const s = encodeWorkspaceState({ v: 1, layout: "1x2", panels: ["chatgpt", "deepseek"], urls: {} });
+    await page.goto(`chrome-extension://${extensionId}/multi-panel/index.html?s=${s}`);
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+    await expect.poll(() => page.locator("iframe").count(), { timeout: 10_000 }).toBeGreaterThanOrEqual(2);
+
+    // Drive the deepseek panel to a "conversation" URL (its content script polls
+    // location.href and reports it back to the workspace).
+    const deepseekFrame = page.frames().find((f) => /deepseek/i.test(f.url()));
+    expect(deepseekFrame, "deepseek iframe present").toBeTruthy();
+    await deepseekFrame!.evaluate(() => history.pushState({}, "", "/a/chat/s/CONV999"));
+
+    // It should be persisted into ?s=.
+    await expect
+      .poll(
+        async () => decodeSearch(await page.evaluate(() => window.location.search))?.urls?.deepseek ?? "",
+        { timeout: 10_000 },
+      )
+      .toContain("CONV999");
+
+    // Reload (F5 keeps ?s=) and confirm the panel reopens the conversation.
+    await page.reload();
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+    await expect
+      .poll(
+        async () => {
+          const frames = await readFrameSrcs(page);
+          return frames.find((f) => /deepseek/i.test(f.title))?.src ?? "";
+        },
+        { timeout: 10_000 },
+      )
+      .toContain("CONV999");
+  });
+
+  test("two temp panels + one regular panel: keeps only the regular panel's URL", async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await stubProviderRequests(page);
+    await page.addInitScript(() => {
+      try {
+        chrome.storage?.local?.set({ onboardingState: { completedVersion: 9999 } });
+      } catch {
+        // ignore
+      }
+    });
+
+    // chatgpt + claude are temp-capable; deepseek is a regular chat.
+    const s = encodeWorkspaceState({
+      v: 1,
+      layout: "1x3",
+      panels: ["chatgpt", "claude", "deepseek"],
+      urls: {},
+    });
+    await page.goto(`chrome-extension://${extensionId}/multi-panel/index.html?s=${s}`);
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+    await expect.poll(() => page.locator("iframe").count(), { timeout: 10_000 }).toBeGreaterThanOrEqual(3);
+
+    const deepseekFrame = page.frames().find((f) => /deepseek/i.test(f.url()));
+    expect(deepseekFrame, "deepseek iframe present").toBeTruthy();
+    await deepseekFrame!.evaluate(() => history.pushState({}, "", "/a/chat/s/CONV999"));
+
+    // Turn temporary chat on -> chatgpt + claude become temp, deepseek stays regular.
+    await page.getByRole("button", { name: /temporary chats/i }).first().click();
+
+    // Only the regular panel is saved; both temp panels are excluded.
+    await expect
+      .poll(
+        async () => {
+          const urls = decodeSearch(await page.evaluate(() => window.location.search))?.urls ?? {};
+          return {
+            deepseek: (urls.deepseek ?? "").includes("CONV999"),
+            hasChatgpt: "chatgpt" in urls,
+            hasClaude: "claude" in urls,
+          };
+        },
+        { timeout: 12_000 },
+      )
+      .toEqual({ deepseek: true, hasChatgpt: false, hasClaude: false });
+  });
+
+  test("a temp-capable panel switched back to a regular chat is saved and restored", async ({
+    context,
+    extensionId,
+  }) => {
+    const page = await context.newPage();
+    await stubProviderRequests(page);
+    await page.addInitScript(() => {
+      try {
+        chrome.storage?.local?.set({ onboardingState: { completedVersion: 9999 } });
+      } catch {
+        // ignore
+      }
+    });
+
+    // Default-style workspace: all three providers are temp-capable.
+    const s = encodeWorkspaceState({
+      v: 1,
+      layout: "1x3",
+      panels: ["chatgpt", "claude", "gemini"],
+      urls: {},
+    });
+    await page.goto(`chrome-extension://${extensionId}/multi-panel/index.html?s=${s}`);
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+    await expect.poll(() => page.locator("iframe").count(), { timeout: 10_000 }).toBeGreaterThanOrEqual(3);
+
+    // Turn temp mode on -> all three become temporary chats.
+    await page.getByRole("button", { name: /temporary chats/i }).first().click();
+
+    // Switch gemini back to a regular conversation (as if toggled out of temp in
+    // gemini's own UI and chatted -> a real conversation URL).
+    await expect
+      .poll(() => page.frames().some((f) => /gemini\.google\.com/i.test(f.url())), { timeout: 10_000 })
+      .toBe(true);
+    const geminiFrame = page.frames().find((f) => /gemini\.google\.com/i.test(f.url()));
+    await geminiFrame!.evaluate(() => history.pushState({}, "", "/app/GEMCONV777"));
+
+    // Only gemini (now regular) is saved; chatgpt + claude (still temp) are dropped.
+    await expect
+      .poll(
+        async () => {
+          const urls = decodeSearch(await page.evaluate(() => window.location.search))?.urls ?? {};
+          return {
+            gemini: (urls.gemini ?? "").includes("GEMCONV777"),
+            hasChatgpt: "chatgpt" in urls,
+            hasClaude: "claude" in urls,
+          };
+        },
+        { timeout: 12_000 },
+      )
+      .toEqual({ gemini: true, hasChatgpt: false, hasClaude: false });
+
+    // It reopens after a reload.
+    await page.reload();
+    await expect(page.locator("#root")).not.toBeEmpty({ timeout: 10_000 });
+    await expect
+      .poll(
+        async () => {
+          const frames = await readFrameSrcs(page);
+          return frames.find((f) => /gemini/i.test(f.title))?.src ?? "";
+        },
+        { timeout: 10_000 },
+      )
+      .toContain("GEMCONV777");
+  });
+});

--- a/tests/hooks/usePanelLayoutController.test.ts
+++ b/tests/hooks/usePanelLayoutController.test.ts
@@ -8,6 +8,7 @@ import type { ProviderId } from "@/shared/lib/providers";
 interface HarnessOverrides {
   enabledProviders?: ProviderId[];
   isHydrated?: boolean;
+  isRestoredTab?: boolean;
 }
 
 function makeHarness(overrides: HarnessOverrides = {}) {
@@ -18,6 +19,7 @@ function makeHarness(overrides: HarnessOverrides = {}) {
       usePanelLayoutController({
         enabledProviders: enabled,
         isHydrated: hydrated,
+        isRestoredTab: overrides.isRestoredTab,
         showStatus,
         updateSetting,
       }),
@@ -176,6 +178,14 @@ describe("usePanelLayoutController", () => {
         h.result.current.setLayout("2x2");
       });
       expect(h.updateSetting).toHaveBeenCalledWith("currentLayout", "2x2");
+    });
+
+    it("does NOT mirror layout/panels to global settings for a restored tab", () => {
+      const h = makeHarness({ isRestoredTab: true });
+      act(() => {
+        h.result.current.setLayout("2x2");
+      });
+      expect(h.updateSetting).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/hooks/useProviderActionsController.test.ts
+++ b/tests/hooks/useProviderActionsController.test.ts
@@ -217,6 +217,45 @@ describe("useProviderActionsController", () => {
       );
       expect(enables).toHaveLength(0);
     });
+
+    it("broadcasts DISABLE_TEMP_CHAT to DOM-toggle providers (Gemini/Qwen) on turn-off", () => {
+      const h = makeHarness({
+        temporaryChatEnabled: true,
+        panelProviders: ["gemini", "qwen", "chatgpt"],
+      });
+      h.result.current.toggleTemporaryChat();
+
+      const disables = h.postToProvider.mock.calls.filter(
+        ([, msg]) => (msg as { type?: string }).type === "DISABLE_TEMP_CHAT",
+      );
+      expect(disables.map(([id]) => id).sort()).toEqual(["gemini", "qwen"]);
+    });
+
+    it("does NOT post DISABLE_TEMP_CHAT to URL-based providers (ChatGPT/Claude)", () => {
+      const h = makeHarness({
+        temporaryChatEnabled: true,
+        panelProviders: ["chatgpt", "claude"],
+      });
+      h.result.current.toggleTemporaryChat();
+
+      const disables = h.postToProvider.mock.calls.filter(
+        ([, msg]) => (msg as { type?: string }).type === "DISABLE_TEMP_CHAT",
+      );
+      expect(disables).toHaveLength(0);
+    });
+
+    it("does NOT broadcast DISABLE_TEMP_CHAT when turning temp on", () => {
+      const h = makeHarness({
+        temporaryChatEnabled: false,
+        panelProviders: ["gemini", "qwen"],
+      });
+      h.result.current.toggleTemporaryChat();
+
+      const disables = h.postToProvider.mock.calls.filter(
+        ([, msg]) => (msg as { type?: string }).type === "DISABLE_TEMP_CHAT",
+      );
+      expect(disables).toHaveLength(0);
+    });
   });
 
   describe("toggleScrollSync", () => {

--- a/tests/hooks/useProviderFramesController.test.ts
+++ b/tests/hooks/useProviderFramesController.test.ts
@@ -11,6 +11,8 @@ interface HarnessOverrides {
   isHydrated?: boolean;
   temporaryChatEnabled?: boolean;
   resolvedTheme?: "light" | "dark";
+  restoredUrlByProvider?: Partial<Record<ProviderId, string>>;
+  resumeEnabled?: boolean;
 }
 
 function makeHarness(overrides: HarnessOverrides = {}) {
@@ -35,6 +37,8 @@ function makeHarness(overrides: HarnessOverrides = {}) {
         queueConnectorLayoutRefresh,
         resolvedTheme: theme,
         temporaryChatEnabled: tempChat,
+        restoredUrlByProvider: overrides.restoredUrlByProvider,
+        resumeEnabled: overrides.resumeEnabled,
       }),
     {
       initialProps: {
@@ -203,6 +207,262 @@ describe("useProviderFramesController", () => {
       });
     });
     expect(Object.keys(h.frameRefs.current)).not.toContain("claude");
+  });
+
+  it("seeds the restored conversation URL on first creation", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt"] as ProviderId[],
+      resumeEnabled: true,
+      restoredUrlByProvider: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+    const host = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost(
+        "chatgpt" as ProviderId,
+        "https://chatgpt.com/",
+        "ChatGPT",
+        host,
+      );
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/c/restored");
+  });
+
+  it("ignores the restored URL when resume is disabled", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt"] as ProviderId[],
+      resumeEnabled: false,
+      restoredUrlByProvider: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+    const host = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost(
+        "chatgpt" as ProviderId,
+        "https://chatgpt.com/",
+        "ChatGPT",
+        host,
+      );
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/");
+  });
+
+  it("does not reload a restored panel to home on re-render", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt"] as ProviderId[],
+      resumeEnabled: true,
+      restoredUrlByProvider: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+    const host = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost(
+        "chatgpt" as ProviderId,
+        "https://chatgpt.com/",
+        "ChatGPT",
+        host,
+      );
+    });
+    const frame = h.frameRefs.current.chatgpt;
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt"] as ProviderId[],
+        mode: "ai",
+        hydrated: true,
+        tempChat: false,
+        theme: "light",
+      });
+    });
+    expect(h.frameRefs.current.chatgpt).toBe(frame);
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/c/restored");
+  });
+
+  it("reloads a restored panel to the temp-chat URL when temp chat turns on", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt"] as ProviderId[],
+      resumeEnabled: true,
+      restoredUrlByProvider: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+    const host = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost(
+        "chatgpt" as ProviderId,
+        "https://chatgpt.com/",
+        "ChatGPT",
+        host,
+      );
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/c/restored");
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt"] as ProviderId[],
+        mode: "ai",
+        hydrated: true,
+        tempChat: true,
+        theme: "light",
+      });
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/?temporary-chat=true");
+  });
+
+  it("defers frame creation until hydrated", () => {
+    const h = makeHarness({ panelProviders: ["chatgpt"] as ProviderId[], isHydrated: false });
+    const host = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost(
+        "chatgpt" as ProviderId,
+        "https://chatgpt.com/",
+        "ChatGPT",
+        host,
+      );
+    });
+    expect(h.frameRefs.current.chatgpt).toBeUndefined();
+
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt"] as ProviderId[],
+        mode: "ai",
+        hydrated: true,
+        tempChat: false,
+        theme: "light",
+      });
+    });
+    expect(h.frameRefs.current.chatgpt).toBeInstanceOf(HTMLIFrameElement);
+  });
+
+  it("reopens the panel's last conversation when removed and re-added", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt", "claude"] as ProviderId[],
+      resumeEnabled: true,
+      restoredUrlByProvider: { claude: "https://claude.ai/chat/restored" },
+    });
+    const hostA = document.createElement("div");
+    const hostB = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost("chatgpt" as ProviderId, "https://chatgpt.com/", "ChatGPT", hostA);
+      h.result.current.registerFrameHost("claude" as ProviderId, "https://claude.ai/new", "Claude", hostB);
+    });
+    expect(h.frameRefs.current.claude?.src).toBe("https://claude.ai/chat/restored");
+
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt"] as ProviderId[],
+        mode: "ai",
+        hydrated: true,
+        tempChat: false,
+        theme: "light",
+      });
+    });
+    expect(h.frameRefs.current.claude).toBeUndefined();
+
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt", "claude"] as ProviderId[],
+        mode: "ai",
+        hydrated: true,
+        tempChat: false,
+        theme: "light",
+      });
+    });
+    const hostC = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost("claude" as ProviderId, "https://claude.ai/new", "Claude", hostC);
+    });
+    expect(h.frameRefs.current.claude?.src).toBe("https://claude.ai/chat/restored");
+  });
+
+  it("reloads a restored panel to a new chat on manual refresh", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt"] as ProviderId[],
+      resumeEnabled: true,
+      restoredUrlByProvider: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+    const host = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost(
+        "chatgpt" as ProviderId,
+        "https://chatgpt.com/",
+        "ChatGPT",
+        host,
+      );
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/c/restored");
+
+    act(() => {
+      // Advance the clock so refreshProvider's timestamp differs from the
+      // initial reload key regardless of whether Date is faked.
+      vi.advanceTimersByTime(10);
+      h.result.current.refreshProvider("chatgpt" as ProviderId);
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/");
+  });
+
+  it("reloads only the Google panel on a Google-mode change, leaving a restored sibling", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt", "google"] as ProviderId[],
+      resumeEnabled: true,
+      restoredUrlByProvider: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+    const hostA = document.createElement("div");
+    const hostB = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost("chatgpt" as ProviderId, "https://chatgpt.com/", "ChatGPT", hostA);
+      h.result.current.registerFrameHost(
+        "google" as ProviderId,
+        "https://www.google.com/search?udm=50",
+        "Google",
+        hostB,
+      );
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/c/restored");
+    expect(h.frameRefs.current.google?.src).toBe("https://www.google.com/search?udm=50");
+
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt", "google"] as ProviderId[],
+        mode: "search",
+        hydrated: true,
+        tempChat: false,
+        theme: "light",
+      });
+    });
+    expect(h.frameRefs.current.google?.src).toBe("https://www.google.com/search");
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/c/restored");
+  });
+
+  it("does not re-restore when temp chat turns back off", () => {
+    const h = makeHarness({
+      panelProviders: ["chatgpt"] as ProviderId[],
+      resumeEnabled: true,
+      restoredUrlByProvider: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+    const host = document.createElement("div");
+    act(() => {
+      h.result.current.registerFrameHost(
+        "chatgpt" as ProviderId,
+        "https://chatgpt.com/",
+        "ChatGPT",
+        host,
+      );
+    });
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt"] as ProviderId[],
+        mode: "ai",
+        hydrated: true,
+        tempChat: true,
+        theme: "light",
+      });
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/?temporary-chat=true");
+
+    act(() => {
+      h.rerender({
+        providers: ["chatgpt"] as ProviderId[],
+        mode: "ai",
+        hydrated: true,
+        tempChat: false,
+        theme: "light",
+      });
+    });
+    expect(h.frameRefs.current.chatgpt?.src).toBe("https://chatgpt.com/");
   });
 
 });

--- a/tests/hooks/useWorkspaceUrlController.test.ts
+++ b/tests/hooks/useWorkspaceUrlController.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderHookWithProviders } from "../helpers/hook";
+import { useWorkspaceUrlController } from "@/multi-panel/hooks/useWorkspaceUrlController";
+import {
+  decodeWorkspaceState,
+  readWorkspaceParam,
+} from "@/multi-panel/lib/workspace-state";
+
+type ControllerProps = Parameters<typeof useWorkspaceUrlController>[0];
+
+function currentState() {
+  return decodeWorkspaceState(readWorkspaceParam(window.location.search));
+}
+
+function makeHarness(overrides: Partial<ControllerProps> = {}) {
+  const initialProps = {
+    isHydrated: true,
+    layout: "1x3",
+    panelProviders: ["chatgpt", "claude"],
+    urlByProvider: {},
+    baselineUrls: {},
+    ...overrides,
+  } satisfies ControllerProps;
+
+  return renderHookWithProviders((props: ControllerProps) => useWorkspaceUrlController(props), {
+    initialProps,
+  });
+}
+
+describe("useWorkspaceUrlController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, "", "/multi-panel/index.html");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("writes the workspace state to the URL after the debounce", () => {
+    makeHarness({ urlByProvider: { chatgpt: "https://chatgpt.com/c/abc" } });
+    expect(currentState()).toBeNull();
+
+    vi.advanceTimersByTime(600);
+
+    const state = currentState();
+    expect(state?.layout).toBe("1x3");
+    expect(state?.panels).toEqual(["chatgpt", "claude"]);
+    expect(state?.urls).toEqual({ chatgpt: "https://chatgpt.com/c/abc" });
+  });
+
+  it("keeps the restored baseline until a live URL arrives", () => {
+    makeHarness({ baselineUrls: { chatgpt: "https://chatgpt.com/c/restored" } });
+
+    vi.advanceTimersByTime(600);
+
+    expect(currentState()?.urls).toEqual({ chatgpt: "https://chatgpt.com/c/restored" });
+  });
+
+  it("prefers the live URL over the baseline", () => {
+    makeHarness({
+      urlByProvider: { chatgpt: "https://chatgpt.com/c/live" },
+      baselineUrls: { chatgpt: "https://chatgpt.com/c/restored" },
+    });
+
+    vi.advanceTimersByTime(600);
+
+    expect(currentState()?.urls).toEqual({ chatgpt: "https://chatgpt.com/c/live" });
+  });
+
+  it("excludes a temporary chat (detected by its URL marker)", () => {
+    makeHarness({
+      urlByProvider: { chatgpt: "https://chatgpt.com/?temporary-chat=true" },
+    });
+
+    vi.advanceTimersByTime(600);
+
+    expect(currentState()?.urls).toEqual({});
+  });
+
+  it("keeps a regular panel while dropping a temp panel in a mixed workspace", () => {
+    makeHarness({
+      panelProviders: ["chatgpt", "deepseek"],
+      urlByProvider: {
+        chatgpt: "https://chatgpt.com/?temporary-chat=true",
+        deepseek: "https://chat.deepseek.com/a/chat/s/xyz",
+      },
+    });
+
+    vi.advanceTimersByTime(600);
+
+    expect(currentState()?.urls).toEqual({
+      deepseek: "https://chat.deepseek.com/a/chat/s/xyz",
+    });
+  });
+
+  it("saves a temp-capable provider that was switched back to a regular chat", () => {
+    // The global temp toggle may still be on, but gemini is on a real
+    // conversation URL (no temp marker), so it must be saved while a still-temp
+    // chatgpt is dropped.
+    makeHarness({
+      panelProviders: ["chatgpt", "gemini"],
+      urlByProvider: {
+        chatgpt: "https://chatgpt.com/?temporary-chat=true",
+        gemini: "https://gemini.google.com/app/GEM123",
+      },
+    });
+
+    vi.advanceTimersByTime(600);
+
+    expect(currentState()?.urls).toEqual({
+      gemini: "https://gemini.google.com/app/GEM123",
+    });
+  });
+
+  it("does not write before hydration", () => {
+    makeHarness({ isHydrated: false, urlByProvider: { chatgpt: "https://chatgpt.com/c/abc" } });
+
+    vi.advanceTimersByTime(600);
+
+    expect(currentState()).toBeNull();
+  });
+});

--- a/tests/hooks/useWorkspaceUrlController.test.ts
+++ b/tests/hooks/useWorkspaceUrlController.test.ts
@@ -121,4 +121,13 @@ describe("useWorkspaceUrlController", () => {
 
     expect(currentState()).toBeNull();
   });
+
+  it("clears a stale workspace param when no panels are active", () => {
+    window.history.replaceState(null, "", "/multi-panel/index.html?s=stale");
+    makeHarness({ panelProviders: [null], urlByProvider: {} });
+
+    vi.advanceTimersByTime(600);
+
+    expect(readWorkspaceParam(window.location.search)).toBeNull();
+  });
 });

--- a/tests/unit/temp-chat-providers.test.ts
+++ b/tests/unit/temp-chat-providers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DOM_TEMP_CHAT_PROVIDERS,
+  NORMAL_URLS,
+  TEMP_CHAT_SUPPORTED_PROVIDERS,
+  TEMP_CHAT_URLS,
+} from "@/shared/lib/constants";
+
+describe("DOM_TEMP_CHAT_PROVIDERS", () => {
+  it("contains the providers whose temp and normal URLs are identical", () => {
+    // Gemini and Qwen share one URL for temp + normal, so temp mode is an
+    // in-page DOM toggle that needs an explicit DISABLE_TEMP_CHAT click.
+    expect([...DOM_TEMP_CHAT_PROVIDERS].sort()).toEqual(["gemini", "qwen"]);
+  });
+
+  it("excludes URL-based temp-chat providers", () => {
+    for (const id of ["chatgpt", "claude", "grok"] as const) {
+      expect(DOM_TEMP_CHAT_PROVIDERS.has(id)).toBe(false);
+    }
+  });
+
+  it("only includes supported providers and stays consistent with the URL maps", () => {
+    for (const id of DOM_TEMP_CHAT_PROVIDERS) {
+      expect(TEMP_CHAT_SUPPORTED_PROVIDERS.has(id)).toBe(true);
+      expect(TEMP_CHAT_URLS[id] ?? null).toBe(NORMAL_URLS[id] ?? null);
+    }
+  });
+});

--- a/tests/unit/workspace-state.test.ts
+++ b/tests/unit/workspace-state.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeWorkspaceState,
+  encodeWorkspaceState,
+  isRestorableProviderUrl,
+  isTemporaryChatUrl,
+  WORKSPACE_STATE_VERSION,
+  type WorkspaceState,
+} from "@/multi-panel/lib/workspace-state";
+
+const baseState: WorkspaceState = {
+  v: WORKSPACE_STATE_VERSION,
+  layout: "1x3",
+  panels: ["chatgpt", "claude", "gemini"],
+  urls: {
+    chatgpt: "https://chatgpt.com/c/abc",
+    claude: "https://claude.ai/chat/def",
+  },
+};
+
+describe("workspace-state", () => {
+  it("round-trips a valid workspace state", () => {
+    expect(decodeWorkspaceState(encodeWorkspaceState(baseState))).toEqual(baseState);
+  });
+
+  it("returns null for empty or malformed params", () => {
+    expect(decodeWorkspaceState(null)).toBeNull();
+    expect(decodeWorkspaceState("")).toBeNull();
+    expect(decodeWorkspaceState("not base64 !!")).toBeNull();
+    expect(decodeWorkspaceState(btoa("{not json"))).toBeNull();
+  });
+
+  it("rejects an unknown schema version", () => {
+    expect(decodeWorkspaceState(encodeWorkspaceState({ ...baseState, v: 2 as never }))).toBeNull();
+  });
+
+  it("rejects an unknown layout", () => {
+    expect(
+      decodeWorkspaceState(encodeWorkspaceState({ ...baseState, layout: "9x9" as never })),
+    ).toBeNull();
+  });
+
+  it("returns null when no real provider remains in panels", () => {
+    expect(decodeWorkspaceState(encodeWorkspaceState({ ...baseState, panels: [null, null] }))).toBeNull();
+  });
+
+  it("drops unknown providers from panels but keeps slot positions", () => {
+    const encoded = encodeWorkspaceState({
+      ...baseState,
+      panels: ["chatgpt", "bogus" as never, "gemini"],
+      urls: {},
+    });
+    expect(decodeWorkspaceState(encoded)?.panels).toEqual(["chatgpt", null, "gemini"]);
+  });
+
+  it("drops non-https, wrong-host, and Google URLs", () => {
+    const encoded = encodeWorkspaceState({
+      ...baseState,
+      panels: ["chatgpt", "claude", "google"],
+      urls: {
+        chatgpt: "http://chatgpt.com/c/abc",
+        claude: "https://evil.example.com/chat/def",
+        google: "https://www.google.com/search?q=x",
+      } as never,
+    });
+    expect(decodeWorkspaceState(encoded)?.urls).toEqual({});
+  });
+
+  describe("isRestorableProviderUrl", () => {
+    it("accepts https URLs on a matching provider host", () => {
+      expect(isRestorableProviderUrl("chatgpt", "https://chatgpt.com/c/abc")).toBe(true);
+      expect(isRestorableProviderUrl("chatgpt", "https://chat.openai.com/c/abc")).toBe(true);
+    });
+
+    it("rejects wrong-host, non-https, Google, and non-URL values", () => {
+      expect(isRestorableProviderUrl("claude", "https://chatgpt.com/c/abc")).toBe(false);
+      expect(isRestorableProviderUrl("chatgpt", "http://chatgpt.com/c/abc")).toBe(false);
+      expect(isRestorableProviderUrl("google", "https://www.google.com/")).toBe(false);
+      expect(isRestorableProviderUrl("chatgpt", "javascript:alert(1)")).toBe(false);
+      expect(isRestorableProviderUrl("chatgpt", 42)).toBe(false);
+    });
+  });
+
+  describe("isTemporaryChatUrl", () => {
+    it("detects URL-markered temporary chats", () => {
+      expect(isTemporaryChatUrl("chatgpt", "https://chatgpt.com/?temporary-chat=true")).toBe(true);
+      expect(isTemporaryChatUrl("claude", "https://claude.ai/new?incognito")).toBe(true);
+      expect(isTemporaryChatUrl("grok", "https://grok.com/c#private")).toBe(true);
+    });
+
+    it("treats real conversation URLs as not temporary", () => {
+      expect(isTemporaryChatUrl("chatgpt", "https://chatgpt.com/c/abc")).toBe(false);
+      expect(isTemporaryChatUrl("claude", "https://claude.ai/chat/abc")).toBe(false);
+      expect(isTemporaryChatUrl("grok", "https://grok.com/c/abc")).toBe(false);
+    });
+
+    it("never marks providers without a URL temp signal (gemini, qwen)", () => {
+      // gemini/qwen temp chats are not URL-distinguishable; their ephemeral
+      // chats sit at base URLs that restore to a fresh chat anyway, and a real
+      // gemini conversation must be saved (the switched-back-to-regular case).
+      expect(isTemporaryChatUrl("gemini", "https://gemini.google.com/app")).toBe(false);
+      expect(isTemporaryChatUrl("gemini", "https://gemini.google.com/app/GEM123")).toBe(false);
+      expect(isTemporaryChatUrl("qwen", "https://chat.qwen.ai/")).toBe(false);
+    });
+  });
+});

--- a/tests/unit/workspace-state.test.ts
+++ b/tests/unit/workspace-state.test.ts
@@ -67,6 +67,23 @@ describe("workspace-state", () => {
     expect(decodeWorkspaceState(encoded)?.urls).toEqual({});
   });
 
+  it("drops temporary-chat URLs from a crafted state", () => {
+    const encoded = encodeWorkspaceState({
+      ...baseState,
+      panels: ["chatgpt", "claude", "grok"],
+      urls: {
+        chatgpt: "https://chatgpt.com/?temporary-chat=true",
+        claude: "https://claude.ai/chat/def",
+        grok: "https://grok.com/c#private",
+      },
+    });
+    // Decode mirrors the write path: temp-chat markers are filtered out, the
+    // regular conversation is kept.
+    expect(decodeWorkspaceState(encoded)?.urls).toEqual({
+      claude: "https://claude.ai/chat/def",
+    });
+  });
+
   describe("isRestorableProviderUrl", () => {
     it("accepts https URLs on a matching provider host", () => {
       expect(isRestorableProviderUrl("chatgpt", "https://chatgpt.com/c/abc")).toBe(true);
@@ -83,7 +100,7 @@ describe("workspace-state", () => {
   });
 
   describe("isTemporaryChatUrl", () => {
-    it("detects URL-markered temporary chats", () => {
+    it("detects URL-marked temporary chats", () => {
       expect(isTemporaryChatUrl("chatgpt", "https://chatgpt.com/?temporary-chat=true")).toBe(true);
       expect(isTemporaryChatUrl("claude", "https://claude.ai/new?incognito")).toBe(true);
       expect(isTemporaryChatUrl("grok", "https://grok.com/c#private")).toBe(true);

--- a/tests/unit/workspace-title.test.ts
+++ b/tests/unit/workspace-title.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_DOCUMENT_TITLE,
+  TEMPORARY_DOCUMENT_TITLE,
+  resolveWorkspaceTitle,
+} from "@/multi-panel/lib/workspace-title";
+
+describe("resolveWorkspaceTitle", () => {
+  it("defaults to the brand title with no active panel", () => {
+    expect(resolveWorkspaceTitle([], {}, false)).toBe(DEFAULT_DOCUMENT_TITLE);
+    expect(resolveWorkspaceTitle([null, null], {}, false)).toBe(DEFAULT_DOCUMENT_TITLE);
+  });
+
+  it("shows the first panel's conversation title when set", () => {
+    const titles = { chatgpt: { title: "My chat", initialTitle: "ChatGPT" } };
+    expect(resolveWorkspaceTitle(["chatgpt"], titles, false)).toBe("My chat");
+  });
+
+  it("falls back to the brand title when the provider title is unset or still the initial", () => {
+    expect(
+      resolveWorkspaceTitle(["chatgpt"], { chatgpt: { title: "ChatGPT", initialTitle: "ChatGPT" } }, false),
+    ).toBe(DEFAULT_DOCUMENT_TITLE);
+    expect(resolveWorkspaceTitle(["chatgpt"], {}, false)).toBe(DEFAULT_DOCUMENT_TITLE);
+  });
+
+  it("shows the temporary title only when every panel is a temporary chat", () => {
+    expect(resolveWorkspaceTitle(["chatgpt", "claude"], {}, true)).toBe(TEMPORARY_DOCUMENT_TITLE);
+    expect(resolveWorkspaceTitle(["chatgpt"], {}, true)).toBe(TEMPORARY_DOCUMENT_TITLE);
+  });
+
+  it("prefers the temporary title over the first panel's conversation title", () => {
+    const titles = { chatgpt: { title: "My chat", initialTitle: "ChatGPT" } };
+    expect(resolveWorkspaceTitle(["chatgpt"], titles, true)).toBe(TEMPORARY_DOCUMENT_TITLE);
+  });
+
+  it("is regular (not temporary) for a mix of temp and regular panels", () => {
+    // chatgpt is a temp chat, deepseek is a regular chat -> a mix is regular,
+    // regardless of order.
+    expect(resolveWorkspaceTitle(["chatgpt", "deepseek"], {}, true)).toBe(DEFAULT_DOCUMENT_TITLE);
+    const titles = { deepseek: { title: "DS chat", initialTitle: "DeepSeek" } };
+    expect(resolveWorkspaceTitle(["deepseek", "chatgpt"], titles, true)).toBe("DS chat");
+  });
+
+  it("is NOT temporary when a panel does not support temp chat", () => {
+    // deepseek can never be a temp chat, so even alone with temp on it is regular.
+    expect(resolveWorkspaceTitle(["deepseek"], {}, true)).toBe(DEFAULT_DOCUMENT_TITLE);
+  });
+
+  it("uses the leftmost non-empty slot as the first panel", () => {
+    expect(resolveWorkspaceTitle([null, "chatgpt"], {}, true)).toBe(TEMPORARY_DOCUMENT_TITLE);
+  });
+});


### PR DESCRIPTION
## What

Persists each panel's provider chat session in the workspace tab URL, so reloading or reopening the workspace restores the same panels and sessions instead of resetting to blank.

## Changes

- **`lib/workspace-state.ts`, `lib/workspace-title.ts`, `hooks/useWorkspaceUrlController.ts`** - encode and restore workspace state (layout + per-panel session) through the tab URL.
- **`hooks/useProviderFramesController.ts`, `useProviderActionsController.ts`, `usePanelLayoutController.ts`** - restore provider frames/sessions on load.
- **`content-scripts/text-injection-all-providers.js`** - restore temp-chat control over Gemini in both directions.
- **Tests** - unit coverage for `workspace-state`, `workspace-title`, the controllers, and temp-chat providers, plus a new `tests/e2e/fixtures/session-restore.spec.ts`.
- **`docs/roadmap/session-persistence.md`** - design notes.

## Release

Ships as the next Chrome Web Store release. `manifest.json` stays at `1.0.3` (store is live at `1.0.2`), so the post-merge tag will be `v1.0.3`.