### PR TITLE
Add What's new changelog and refine global tooltips

### DIFF
--- a/src/multi-panel/App.tsx
+++ b/src/multi-panel/App.tsx
@@ -18,6 +18,8 @@ import { PanelWorkspace } from "@/multi-panel/components/PanelWorkspace";
 import { SettingsModal } from "@/multi-panel/components/SettingsModal";
 import { OnboardingTour } from "@/multi-panel/onboarding/OnboardingTour";
 import { useOnboardingTour } from "@/multi-panel/onboarding/useOnboardingTour";
+import { ChangelogToast } from "@/multi-panel/whats-new/ChangelogToast";
+import { useChangelog } from "@/multi-panel/whats-new/useChangelog";
 import { useComposerDraftController } from "@/multi-panel/hooks/useComposerDraftController";
 import { useComposerFrameController } from "@/multi-panel/hooks/useComposerFrameController";
 import { useConnectorController } from "@/multi-panel/hooks/useConnectorController";
@@ -315,6 +317,12 @@ export function App() {
       openPromptQuickPick: () => setPromptQuickPickOpen(true),
       closePromptQuickPick: () => setPromptQuickPickOpen(false),
     },
+  });
+
+  // Gate on the tour being idle so a "what's new" toast never stacks on the
+  // first-run onboarding overlay.
+  const changelog = useChangelog({
+    ready: loaded && isHydrated && onboardingTour.phase === "idle",
   });
 
   useEffect(() => {
@@ -653,6 +661,7 @@ export function App() {
       />
 
       <OnboardingTour tour={onboardingTour} />
+      <ChangelogToast changelog={changelog} />
     </div>
   );
 }

--- a/src/multi-panel/components/PromptLibraryModal.tsx
+++ b/src/multi-panel/components/PromptLibraryModal.tsx
@@ -213,8 +213,6 @@ export function PromptLibraryModal({
           <FilePickerButton
             accept="application/json"
             onPick={onImportFile}
-
-            title={t("libraryImportPromptsJsonTitle", "Import prompts JSON")}
             variant="secondary"
           >
             <Download size={14} />

--- a/src/multi-panel/components/SettingsModal.tsx
+++ b/src/multi-panel/components/SettingsModal.tsx
@@ -666,7 +666,6 @@ export function SettingsModal({
                   <FilePickerButton
                     accept="application/json"
                     onPick={(file) => void onImportPromptFile(file)}
-                    title={t("libraryImportJsonTitle", "Import prompt library JSON")}
                     variant="secondary"
                   >
                     <Download size={16} />
@@ -719,7 +718,6 @@ export function SettingsModal({
                   <FilePickerButton
                     accept="application/json"
                     onPick={(file) => void onImportSettingsFile(file)}
-                    title={t("dataImportSettingsTitle", "Import settings JSON")}
                     variant="secondary"
                   >
                     <Download size={16} />

--- a/src/multi-panel/components/SettingsModal.tsx
+++ b/src/multi-panel/components/SettingsModal.tsx
@@ -41,6 +41,9 @@ import {
   type SourceUrlPlacement,
 } from "@/shared/lib/settings";
 import type { UpdateStatus, VersionInfo } from "@/shared/lib/version-checker";
+import { getLatestChangelogEntry } from "@/multi-panel/whats-new/changelog";
+
+const LATEST_CHANGELOG = getLatestChangelogEntry();
 
 interface SettingsModalProps {
   assetUrl: (path: string) => string;
@@ -765,6 +768,30 @@ export function SettingsModal({
 
           {settingsTab === "about" ? (
             <>
+              {LATEST_CHANGELOG ? (
+                <SettingItem
+                  description={t("aboutWhatsNewDescription", "Highlights from the latest release.")}
+                  title={t("aboutWhatsNewTitle", "What's new")}
+                >
+                  <div className="squircle rounded-2xl border border-[hsl(var(--border-muted)/0.08)] p-3">
+                    <div className="mb-2 text-sm font-medium text-[hsl(var(--foreground))]">
+                      v{LATEST_CHANGELOG.version}
+                    </div>
+                    <ul className="space-y-2 text-sm text-[hsl(var(--foreground-muted))]">
+                      {LATEST_CHANGELOG.highlights.map((highlight) => (
+                        <li className="flex gap-2" key={highlight}>
+                          <span
+                            aria-hidden
+                            className="mt-1.5 size-1.5 shrink-0 rounded-full bg-[hsl(var(--foreground-muted))]"
+                          />
+                          <span>{highlight}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </SettingItem>
+              ) : null}
+
               <SettingItem
                 description={t(
                   "aboutTutorialDescription",
@@ -806,23 +833,24 @@ export function SettingsModal({
                   "Runs the packaged version check using the local build metadata.",
                 )}
                 title={t("aboutUpdateCheckTitle", "Update check")}
-              >
-                <div className="flex flex-wrap items-center gap-3">
-                  <Button onClick={() => void onRunVersionCheck()} variant="secondary">
-                    {checking ? <LoaderCircle className="animate-spin" size={16} /> : null}
-                    {t("aboutCheckVersion", "Check version")}
-                  </Button>
-                  {updateStatus ? (
-                    <InfoBadge>
-                      {updateStatus.error
-                        ? updateStatus.error
-                        : updateStatus.updateAvailable
-                          ? t("aboutUpdateAvailable", "Newer metadata version available: $1", updateStatus.latestVersion)
-                          : t("aboutUpToDate", "You are on $1.", updateStatus.currentVersion)}
-                    </InfoBadge>
-                  ) : null}
-                </div>
-              </SettingItem>
+                trailing={
+                  <div className="flex flex-wrap items-center justify-end gap-3">
+                    <Button onClick={() => void onRunVersionCheck()} variant="secondary">
+                      {checking ? <LoaderCircle className="animate-spin" size={16} /> : null}
+                      {t("aboutCheckVersion", "Check version")}
+                    </Button>
+                    {updateStatus ? (
+                      <InfoBadge>
+                        {updateStatus.error
+                          ? updateStatus.error
+                          : updateStatus.updateAvailable
+                            ? t("aboutUpdateAvailable", "Newer metadata version available: $1", updateStatus.latestVersion)
+                            : t("aboutUpToDate", "You are on $1.", updateStatus.currentVersion)}
+                      </InfoBadge>
+                    ) : null}
+                  </div>
+                }
+              />
             </>
           ) : null}
         </div>

--- a/src/multi-panel/whats-new/ChangelogToast.tsx
+++ b/src/multi-panel/whats-new/ChangelogToast.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
+
+import { Button } from "@/shared/components/Button";
+import { useTranslation } from "@/shared/contexts/I18nContext";
+import type { ChangelogController } from "./useChangelog";
+
+interface Anchor {
+  left: number;
+  bottom: number;
+}
+
+const GAP_ABOVE_COMPOSER = 12;
+
+// Centre the toast horizontally on the floating composer and sit it just above
+// the composer's top edge. Falls back to the bottom-centre of the viewport when
+// the composer isn't mounted (e.g. unit tests).
+function measureAnchor(): Anchor {
+  const composer =
+    typeof document !== "undefined" ? document.querySelector(".composer-shell") : null;
+  if (composer) {
+    const rect = composer.getBoundingClientRect();
+    return {
+      left: rect.left + rect.width / 2,
+      bottom: window.innerHeight - rect.top + GAP_ABOVE_COMPOSER,
+    };
+  }
+  const width = typeof window !== "undefined" ? window.innerWidth : 0;
+  return { left: width / 2, bottom: 24 };
+}
+
+// Bolds the lead term before the first ": " (e.g. "Session persistence: ...").
+// Highlights without that separator render as plain text.
+function HighlightText({ text }: { text: string }) {
+  const sep = text.indexOf(": ");
+  if (sep === -1) {
+    return <>{text}</>;
+  }
+  return (
+    <>
+      <strong className="font-semibold text-[hsl(var(--foreground))]">{text.slice(0, sep)}</strong>
+      {text.slice(sep)}
+    </>
+  );
+}
+
+/**
+ * A small, dismissible "what's new" toast that floats just above the composer.
+ * Renders nothing unless the controller has an entry to show. Slides in unless
+ * the user prefers reduced motion.
+ */
+export function ChangelogToast({ changelog }: { changelog: ChangelogController }) {
+  const { t } = useTranslation();
+  const { entry, dismiss } = changelog;
+
+  const reducedMotion = useMemo(
+    () => window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+    [],
+  );
+  const [shown, setShown] = useState(false);
+  const [anchor, setAnchor] = useState<Anchor>(measureAnchor);
+
+  useEffect(() => {
+    if (!entry || reducedMotion || typeof window.requestAnimationFrame !== "function") {
+      setShown(true);
+      return;
+    }
+    const id = window.requestAnimationFrame(() => setShown(true));
+    return () => window.cancelAnimationFrame(id);
+  }, [entry, reducedMotion]);
+
+  useEffect(() => {
+    if (!entry) {
+      return;
+    }
+    const update = () => setAnchor(measureAnchor());
+    update();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    // The composer can be dragged or resized while the toast is up; keep tracking.
+    const interval = window.setInterval(update, 500);
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+      window.clearInterval(interval);
+    };
+  }, [entry]);
+
+  if (!entry) {
+    return null;
+  }
+
+  const settled = reducedMotion || shown;
+
+  return (
+    <div
+      aria-live="polite"
+      className={`fixed z-50 w-88 max-w-[calc(100vw-2rem)] rounded-[20px] border border-[hsl(var(--border-muted)/0.08)] bg-[hsl(var(--surface-panel))] p-4 text-[hsl(var(--foreground))] shadow-[0_24px_80px_-42px_hsl(var(--shadow-ambient)/0.9)] ${
+        reducedMotion ? "" : "transition-[opacity,transform] duration-300 ease-out"
+      }`}
+      data-whats-new-toast
+      role="status"
+      style={{
+        bottom: anchor.bottom,
+        left: anchor.left,
+        opacity: settled ? 1 : 0,
+        transform: `translateX(-50%) translateY(${settled ? "0" : "0.75rem"})`,
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="font-semibold text-[hsl(var(--foreground))]">
+          {t("whatsNewTitle", "What's new")}
+          <span className="ml-1.5 text-[hsl(var(--foreground-muted))]">v{entry.version}</span>
+        </div>
+        <button
+          aria-label={t("whatsNewDismiss", "Dismiss")}
+          className="rounded-lg p-1 text-[hsl(var(--foreground-muted))] transition hover:bg-[hsl(var(--surface-popover))] hover:text-[hsl(var(--foreground))]"
+          onClick={dismiss}
+          type="button"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      <ul className="mt-3 space-y-2 text-sm text-[hsl(var(--foreground-muted))]">
+        {entry.highlights.map((highlight) => (
+          <li className="flex gap-2" key={highlight}>
+            <span
+              aria-hidden
+              className="mt-1.5 size-1.5 shrink-0 rounded-full bg-[hsl(var(--foreground-muted))]"
+            />
+            <span>
+              <HighlightText text={highlight} />
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-4 flex justify-end">
+        <Button onClick={dismiss} size="sm" variant="primary">
+          {t("whatsNewGotIt", "Got it")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/multi-panel/whats-new/ChangelogToast.tsx
+++ b/src/multi-panel/whats-new/ChangelogToast.tsx
@@ -78,7 +78,12 @@ export function ChangelogToast({ changelog }: { changelog: ChangelogController }
     if (!entry) {
       return;
     }
-    const update = () => setAnchor(measureAnchor());
+    const update = () => {
+      const next = measureAnchor();
+      setAnchor((prev) =>
+        prev.left === next.left && prev.bottom === next.bottom ? prev : next,
+      );
+    };
     update();
     window.addEventListener("resize", update);
     window.addEventListener("scroll", update, true);
@@ -99,7 +104,6 @@ export function ChangelogToast({ changelog }: { changelog: ChangelogController }
 
   return (
     <div
-      aria-live="polite"
       className={`fixed z-50 w-88 max-w-[calc(100vw-2rem)] rounded-[20px] border border-[hsl(var(--border-muted)/0.08)] bg-[hsl(var(--surface-panel))] p-4 text-[hsl(var(--foreground))] shadow-[0_24px_80px_-42px_hsl(var(--shadow-ambient)/0.9)] ${
         reducedMotion ? "" : "transition-[opacity,transform] duration-300 ease-out"
       }`}

--- a/src/multi-panel/whats-new/ChangelogToast.tsx
+++ b/src/multi-panel/whats-new/ChangelogToast.tsx
@@ -61,7 +61,12 @@ export function ChangelogToast({ changelog }: { changelog: ChangelogController }
   const [anchor, setAnchor] = useState<Anchor>(measureAnchor);
 
   useEffect(() => {
-    if (!entry || reducedMotion || typeof window.requestAnimationFrame !== "function") {
+    if (!entry) {
+      // Reset so the toast slides in the next time it appears.
+      setShown(false);
+      return;
+    }
+    if (reducedMotion || typeof window.requestAnimationFrame !== "function") {
       setShown(true);
       return;
     }

--- a/src/multi-panel/whats-new/changelog-storage.ts
+++ b/src/multi-panel/whats-new/changelog-storage.ts
@@ -2,9 +2,9 @@
 //
 // Lives in chrome.storage.local (per-device, like onboarding) and records the
 // highest CHANGELOG_VERSION the user has seen. A *missing* key means a fresh
-// install or a user predating this feature: the controller initializes it to
-// the current version silently, so the changelog only starts surfacing on the
-// NEXT notable release, never retroactively.
+// install or a user predating this feature; useChangelog decides what that
+// means: a fresh install is suppressed (the onboarding tour welcomes them),
+// while an already-onboarded user sees the latest highlights once.
 
 import { CHANGELOG_VERSION } from "./changelog";
 

--- a/src/multi-panel/whats-new/changelog-storage.ts
+++ b/src/multi-panel/whats-new/changelog-storage.ts
@@ -1,0 +1,57 @@
+// "What's new" seen-state.
+//
+// Lives in chrome.storage.local (per-device, like onboarding) and records the
+// highest CHANGELOG_VERSION the user has seen. A *missing* key means a fresh
+// install or a user predating this feature: the controller initializes it to
+// the current version silently, so the changelog only starts surfacing on the
+// NEXT notable release, never retroactively.
+
+import { CHANGELOG_VERSION } from "./changelog";
+
+export const CHANGELOG_STATE_KEY = "changelogState";
+
+export interface ChangelogState {
+  /** Highest CHANGELOG_VERSION the user has seen. */
+  seenVersion: number;
+}
+
+function hasLocalStorage(): boolean {
+  return typeof chrome !== "undefined" && Boolean(chrome.storage?.local);
+}
+
+/**
+ * Reads the stored state, or null when nothing valid has ever been written
+ * (fresh install / pre-feature user). Distinguishing absent from zero is what
+ * lets the controller suppress the toast on first run.
+ */
+export async function readChangelogState(): Promise<ChangelogState | null> {
+  if (!hasLocalStorage()) {
+    return null;
+  }
+
+  try {
+    const result = await chrome.storage.local.get(CHANGELOG_STATE_KEY);
+    const raw = result[CHANGELOG_STATE_KEY] as Partial<ChangelogState> | undefined;
+    if (!raw || typeof raw.seenVersion !== "number" || !Number.isFinite(raw.seenVersion)) {
+      return null;
+    }
+    return { seenVersion: raw.seenVersion };
+  } catch {
+    return null;
+  }
+}
+
+/** Marks the current CHANGELOG_VERSION as seen so the toast won't show again. */
+export async function markChangelogSeen(): Promise<void> {
+  if (!hasLocalStorage()) {
+    return;
+  }
+
+  try {
+    await chrome.storage.local.set({
+      [CHANGELOG_STATE_KEY]: { seenVersion: CHANGELOG_VERSION },
+    });
+  } catch {
+    // Best-effort; non-critical state.
+  }
+}

--- a/src/multi-panel/whats-new/changelog.ts
+++ b/src/multi-panel/whats-new/changelog.ts
@@ -1,0 +1,34 @@
+// What's-new changelog.
+//
+// Each notable release prepends an entry below AND bumps CHANGELOG_VERSION, so
+// existing users see a one-time "what's new" toast on their next launch after
+// updating. Patch releases with no user-facing changes leave both untouched and
+// stay silent. The newest entry (CHANGELOG[0]) drives both the toast and the
+// Settings -> About "What's new" panel.
+
+export interface ChangelogEntry {
+  /** Display version, e.g. "1.0.4". */
+  version: string;
+  /** Short, user-facing highlights. Keep to a few lines. */
+  highlights: string[];
+}
+
+// Monotonic counter bumped whenever a release adds a user-facing entry below.
+// Kept separate from the semantic version so silent patch releases don't trip
+// the toast; it is the value compared against the user's last-seen marker.
+export const CHANGELOG_VERSION = 1;
+
+// Newest first.
+export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: "1.0.3",
+    highlights: [
+      "Session persistence: your panels and conversations now reopen where you left them after a reload or restart.",
+    ],
+  },
+];
+
+/** The entry surfaced in the toast and About panel (newest), or null if empty. */
+export function getLatestChangelogEntry(): ChangelogEntry | null {
+  return CHANGELOG[0] ?? null;
+}

--- a/src/multi-panel/whats-new/useChangelog.ts
+++ b/src/multi-panel/whats-new/useChangelog.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { TOUR_VERSION, readOnboardingState } from "@/multi-panel/onboarding/onboarding-storage";
+import { CHANGELOG_VERSION, getLatestChangelogEntry, type ChangelogEntry } from "./changelog";
+import { markChangelogSeen, readChangelogState } from "./changelog-storage";
+
+export interface ChangelogController {
+  /** The entry to surface in the toast, or null when nothing should show. */
+  entry: ChangelogEntry | null;
+  /** Dismiss the toast. The seen-state was already persisted when it appeared. */
+  dismiss: () => void;
+}
+
+/**
+ * Decides whether to surface the "what's new" toast.
+ *
+ * The decision is made once at mount from the stored marker (so it reflects
+ * true load-time state, before the onboarding tour can complete and shift it),
+ * while `ready` only gates *display* — pass it false until the app is hydrated
+ * and the tour is idle, so the toast never stacks on the first-run overlay.
+ *
+ * - Marker behind CHANGELOG_VERSION: show once (the normal update case).
+ * - No marker yet: initialize it. A brand-new install (onboarding not completed
+ *   — the tour handles their welcome) stays silent; an existing user updating
+ *   into the first build that ships the changelog sees the highlights once.
+ */
+export function useChangelog({ ready }: { ready: boolean }): ChangelogController {
+  const [pending, setPending] = useState<ChangelogEntry | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const [state, onboarding] = await Promise.all([
+        readChangelogState(),
+        readOnboardingState(),
+      ]);
+      if (cancelled) {
+        return;
+      }
+
+      // Already current — nothing new to show.
+      const behind = state === null || state.seenVersion < CHANGELOG_VERSION;
+      if (!behind) {
+        return;
+      }
+
+      // Advance the marker so this only happens once. Suppress on a genuine fresh
+      // install (no marker AND onboarding unfinished — the tour welcomes them);
+      // everyone else sees the latest highlights once.
+      void markChangelogSeen();
+      const isFreshInstall = state === null && onboarding.completedVersion < TOUR_VERSION;
+      const latest = getLatestChangelogEntry();
+      if (latest && !isFreshInstall) {
+        setPending(latest);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const dismiss = useCallback(() => setDismissed(true), []);
+
+  return { entry: ready && !dismissed ? pending : null, dismiss };
+}

--- a/src/multi-panel/whats-new/useChangelog.ts
+++ b/src/multi-panel/whats-new/useChangelog.ts
@@ -7,7 +7,8 @@ import { markChangelogSeen, readChangelogState } from "./changelog-storage";
 export interface ChangelogController {
   /** The entry to surface in the toast, or null when nothing should show. */
   entry: ChangelogEntry | null;
-  /** Dismiss the toast. The seen-state was already persisted when it appeared. */
+  /** Hide the toast. The seen marker is persisted when the entry is decided (at
+   * mount), independent of whether the toast ever renders. */
   dismiss: () => void;
 }
 

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -28,18 +28,19 @@ const sizeClasses: Record<ButtonSize, string> = {
   iconSm: "h-8 w-8 shrink-0 justify-center px-0",
 };
 
-// A button gets a tooltip only when it has no visible text label (icon-only
-// buttons). For text buttons the label is already on screen, so a tooltip — even
-// an explicit one — would just repeat it.
-function hasVisibleText(children: ReactNode): boolean {
+// A button gets a tooltip only when it has no text label (icon-only buttons).
+// For a text button the label is already on screen, so a tooltip — even an
+// explicit one — would just repeat it. This checks for any text node and can't
+// know CSS visibility, so screen-reader-only text counts as a label too.
+function hasTextLabel(children: ReactNode): boolean {
   if (typeof children === "string" || typeof children === "number") {
     return String(children).trim().length > 0;
   }
   if (Array.isArray(children)) {
-    return children.some(hasVisibleText);
+    return children.some(hasTextLabel);
   }
   if (isValidElement<{ children?: ReactNode }>(children)) {
-    return hasVisibleText(children.props.children);
+    return hasTextLabel(children.props.children);
   }
   return false;
 }
@@ -54,7 +55,7 @@ export function Button({
   variant = "secondary",
   ...props
 }: PropsWithChildren<ButtonProps>) {
-  const tooltip = hasVisibleText(children) ? undefined : (title ?? ariaLabel);
+  const tooltip = hasTextLabel(children) ? undefined : (title ?? ariaLabel);
 
   return (
     <button

--- a/src/shared/components/Button.tsx
+++ b/src/shared/components/Button.tsx
@@ -28,24 +28,20 @@ const sizeClasses: Record<ButtonSize, string> = {
   iconSm: "h-8 w-8 shrink-0 justify-center px-0",
 };
 
-function getTextFromChildren(children: ReactNode): string | undefined {
+// A button gets a tooltip only when it has no visible text label (icon-only
+// buttons). For text buttons the label is already on screen, so a tooltip — even
+// an explicit one — would just repeat it.
+function hasVisibleText(children: ReactNode): boolean {
   if (typeof children === "string" || typeof children === "number") {
-    return String(children).trim() || undefined;
+    return String(children).trim().length > 0;
   }
-
   if (Array.isArray(children)) {
-    return children
-      .map((child) => getTextFromChildren(child))
-      .filter(Boolean)
-      .join(" ")
-      .trim() || undefined;
+    return children.some(hasVisibleText);
   }
-
   if (isValidElement<{ children?: ReactNode }>(children)) {
-    return getTextFromChildren(children.props.children);
+    return hasVisibleText(children.props.children);
   }
-
-  return undefined;
+  return false;
 }
 
 export function Button({
@@ -58,7 +54,7 @@ export function Button({
   variant = "secondary",
   ...props
 }: PropsWithChildren<ButtonProps>) {
-  const tooltip = title ?? ariaLabel ?? getTextFromChildren(children);
+  const tooltip = hasVisibleText(children) ? undefined : (title ?? ariaLabel);
 
   return (
     <button

--- a/src/shared/components/TooltipProvider.tsx
+++ b/src/shared/components/TooltipProvider.tsx
@@ -9,6 +9,7 @@ interface TooltipState {
 
 const TOOLTIP_MARGIN = 12;
 const HOVER_DELAY_MS = 200;
+const HIDE_DELAY_MS = 500;
 
 function readTooltipTarget(target: EventTarget | null) {
   if (!(target instanceof Element)) {
@@ -53,6 +54,7 @@ export function TooltipProvider() {
     let activeTarget: HTMLElement | null = null;
     let pendingTarget: HTMLElement | null = null;
     let hoverTimer: number | null = null;
+    let hideTimer: number | null = null;
 
     const clearHoverTimer = () => {
       if (hoverTimer !== null) {
@@ -62,10 +64,29 @@ export function TooltipProvider() {
       pendingTarget = null;
     };
 
+    const clearHideTimer = () => {
+      if (hideTimer !== null) {
+        window.clearTimeout(hideTimer);
+        hideTimer = null;
+      }
+    };
+
     const showTooltip = (target: HTMLElement | null) => {
       clearHoverTimer();
+      clearHideTimer();
       activeTarget = target;
       setTooltip(target ? getTooltipState(target) : null);
+    };
+
+    // Hide after a grace period so brushing off the trigger (or crossing a small
+    // gap) doesn't make the tooltip flicker away. Re-hovering cancels it.
+    const scheduleHide = () => {
+      clearHideTimer();
+      hideTimer = window.setTimeout(() => {
+        hideTimer = null;
+        activeTarget = null;
+        setTooltip(null);
+      }, HIDE_DELAY_MS);
     };
 
     const scheduleHoverTooltip = (target: HTMLElement) => {
@@ -92,6 +113,9 @@ export function TooltipProvider() {
         return;
       }
 
+      // Back on a tooltip target — cancel any pending hide.
+      clearHideTimer();
+
       if (target === activeTarget || target === pendingTarget) {
         return;
       }
@@ -117,7 +141,7 @@ export function TooltipProvider() {
         return;
       }
 
-      showTooltip(null);
+      scheduleHide();
     };
 
     const handleFocusIn = (event: FocusEvent) => {
@@ -148,6 +172,7 @@ export function TooltipProvider() {
 
     return () => {
       clearHoverTimer();
+      clearHideTimer();
       document.removeEventListener("pointerover", handlePointerOver);
       document.removeEventListener("pointerout", handlePointerOut);
       document.removeEventListener("focusin", handleFocusIn);

--- a/tests/components/Button.test.tsx
+++ b/tests/components/Button.test.tsx
@@ -31,29 +31,37 @@ describe("Button", () => {
     expect(getByRole("button", { name: /settings/i })).toBeInTheDocument();
   });
 
-  it("uses aria-label as tooltip when title is missing", () => {
+  it("uses aria-label as tooltip for an icon-only button when title is missing", () => {
     const { getByRole } = renderWithProviders(
-      <Button aria-label="Open Settings">x</Button>,
+      <Button aria-label="Open Settings"><svg aria-hidden /></Button>,
       { withoutI18n: true, withoutSettings: true, withoutProviders: true },
     );
     expect(getByRole("button")).toHaveAttribute("data-tooltip", "Open Settings");
   });
 
-  it("uses explicit title over aria-label for tooltip", () => {
+  it("uses explicit title over aria-label for an icon-only button", () => {
     const { getByRole } = renderWithProviders(
-      <Button aria-label="x" title="Custom Title">y</Button>,
+      <Button aria-label="x" title="Custom Title"><svg aria-hidden /></Button>,
       { withoutI18n: true, withoutSettings: true, withoutProviders: true },
     );
     expect(getByRole("button")).toHaveAttribute("data-tooltip", "Custom Title");
   });
 
-  it("falls back to inferring tooltip from text children", () => {
+  it("suppresses the tooltip for a button with a text label even when a title is set", () => {
+    const { getByRole } = renderWithProviders(
+      <Button title="Import prompt library JSON"><svg aria-hidden /> Import JSON</Button>,
+      { withoutI18n: true, withoutSettings: true, withoutProviders: true },
+    );
+    expect(getByRole("button")).not.toHaveAttribute("data-tooltip");
+  });
+
+  it("does not add a tooltip for a text-only button (label is already visible)", () => {
     const { getByRole } = renderWithProviders(<Button>Save changes</Button>, {
       withoutI18n: true,
       withoutSettings: true,
       withoutProviders: true,
     });
-    expect(getByRole("button")).toHaveAttribute("data-tooltip", "Save changes");
+    expect(getByRole("button")).not.toHaveAttribute("data-tooltip");
   });
 
   it("does not fire onClick when disabled", async () => {

--- a/tests/components/TooltipProvider.test.tsx
+++ b/tests/components/TooltipProvider.test.tsx
@@ -112,6 +112,69 @@ describe("TooltipProvider", () => {
     expect(queryByRole("tooltip")).toBeNull();
   });
 
+  function pointerOut(target: HTMLElement) {
+    const evt = new Event("pointerout", { bubbles: true });
+    Object.defineProperty(evt, "target", { value: target });
+    Object.defineProperty(evt, "relatedTarget", { value: null });
+    document.dispatchEvent(evt);
+  }
+
+  function showTooltip(text: string) {
+    const target = makeTarget(text);
+    const evt = new Event("pointerover", { bubbles: true });
+    Object.defineProperty(evt, "target", { value: target });
+    act(() => {
+      document.dispatchEvent(evt);
+      vi.advanceTimersByTime(250);
+    });
+    return target;
+  }
+
+  it("delays hiding the tooltip for 500ms after pointer-out", () => {
+    const { getByRole, queryByRole } = renderWithProviders(<TooltipProvider />, {
+      withoutI18n: true,
+      withoutSettings: true,
+      withoutProviders: true,
+    });
+    const target = showTooltip("Lingering");
+    expect(getByRole("tooltip")).toBeInTheDocument();
+
+    act(() => {
+      pointerOut(target);
+      vi.advanceTimersByTime(450);
+    });
+    expect(queryByRole("tooltip")).toBeInTheDocument(); // still within the grace period
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(queryByRole("tooltip")).toBeNull(); // hidden after 500ms
+  });
+
+  it("cancels the pending hide when the pointer returns", () => {
+    const { getByRole, queryByRole } = renderWithProviders(<TooltipProvider />, {
+      withoutI18n: true,
+      withoutSettings: true,
+      withoutProviders: true,
+    });
+    const target = showTooltip("Sticky");
+
+    act(() => {
+      pointerOut(target);
+      vi.advanceTimersByTime(300);
+    });
+    expect(queryByRole("tooltip")).toBeInTheDocument();
+
+    // Pointer comes back onto the trigger before the grace period elapses.
+    const backEvt = new Event("pointerover", { bubbles: true });
+    Object.defineProperty(backEvt, "target", { value: target });
+    act(() => {
+      document.dispatchEvent(backEvt);
+      vi.advanceTimersByTime(400);
+    });
+    expect(getByRole("tooltip")).toBeInTheDocument(); // hide was cancelled
+  });
+
   it("shows tooltip immediately on focusin", () => {
     const { getByRole } = renderWithProviders(<TooltipProvider />, {
       withoutI18n: true,

--- a/tests/multi-panel/whats-new/ChangelogToast.test.tsx
+++ b/tests/multi-panel/whats-new/ChangelogToast.test.tsx
@@ -1,0 +1,47 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "../../helpers/render";
+import { ChangelogToast } from "@/multi-panel/whats-new/ChangelogToast";
+
+const entry = {
+  version: "1.0.3",
+  highlights: ["Session persistence is here.", "Faster reloads."],
+};
+
+describe("ChangelogToast", () => {
+  it("renders nothing without an entry", () => {
+    const { container } = renderWithProviders(
+      <ChangelogToast changelog={{ entry: null, dismiss: vi.fn() }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the version and highlights", () => {
+    renderWithProviders(<ChangelogToast changelog={{ entry, dismiss: vi.fn() }} />);
+    expect(screen.getByText("What's new")).toBeInTheDocument();
+    expect(screen.getByText("v1.0.3")).toBeInTheDocument();
+    for (const highlight of entry.highlights) {
+      expect(screen.getByText(highlight)).toBeInTheDocument();
+    }
+  });
+
+  it("bolds the lead term before the colon", () => {
+    const colonEntry = {
+      version: "1.0.4",
+      highlights: ["Session persistence: it reopens your panels."],
+    };
+    const { container } = renderWithProviders(
+      <ChangelogToast changelog={{ entry: colonEntry, dismiss: vi.fn() }} />,
+    );
+    expect(container.querySelector("strong")).toHaveTextContent("Session persistence");
+  });
+
+  it("dismisses from Got it and the close button", async () => {
+    const dismiss = vi.fn();
+    const { user } = renderWithProviders(<ChangelogToast changelog={{ entry, dismiss }} />);
+    await user.click(screen.getByRole("button", { name: "Got it" }));
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+    expect(dismiss).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/multi-panel/whats-new/changelog-storage.test.ts
+++ b/tests/multi-panel/whats-new/changelog-storage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { readStorage, seedStorage } from "../../setup/chrome-mock";
+import { CHANGELOG_VERSION } from "@/multi-panel/whats-new/changelog";
+import {
+  CHANGELOG_STATE_KEY,
+  markChangelogSeen,
+  readChangelogState,
+} from "@/multi-panel/whats-new/changelog-storage";
+
+describe("changelog-storage", () => {
+  it("returns null when nothing is stored (fresh install)", async () => {
+    expect(await readChangelogState()).toBeNull();
+  });
+
+  it("markChangelogSeen writes the current CHANGELOG_VERSION", async () => {
+    await markChangelogSeen();
+    expect(readStorage("local")[CHANGELOG_STATE_KEY]).toEqual({ seenVersion: CHANGELOG_VERSION });
+    expect(await readChangelogState()).toEqual({ seenVersion: CHANGELOG_VERSION });
+  });
+
+  it("reads a previously stored seenVersion", async () => {
+    seedStorage("local", { [CHANGELOG_STATE_KEY]: { seenVersion: 0 } });
+    expect(await readChangelogState()).toEqual({ seenVersion: 0 });
+  });
+
+  it("treats malformed state as absent", async () => {
+    seedStorage("local", { [CHANGELOG_STATE_KEY]: { seenVersion: "nope" } });
+    expect(await readChangelogState()).toBeNull();
+  });
+
+  it("no-ops gracefully without chrome.storage", async () => {
+    const holder = globalThis as { chrome?: typeof chrome };
+    const original = holder.chrome;
+    delete holder.chrome;
+    try {
+      expect(await readChangelogState()).toBeNull();
+      await expect(markChangelogSeen()).resolves.toBeUndefined();
+    } finally {
+      holder.chrome = original;
+    }
+  });
+});

--- a/tests/multi-panel/whats-new/useChangelog.test.ts
+++ b/tests/multi-panel/whats-new/useChangelog.test.ts
@@ -1,0 +1,73 @@
+import { act, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { readStorage, seedStorage } from "../../setup/chrome-mock";
+import { ONBOARDING_STATE_KEY, TOUR_VERSION } from "@/multi-panel/onboarding/onboarding-storage";
+import { CHANGELOG_VERSION, getLatestChangelogEntry } from "@/multi-panel/whats-new/changelog";
+import { CHANGELOG_STATE_KEY } from "@/multi-panel/whats-new/changelog-storage";
+import { useChangelog } from "@/multi-panel/whats-new/useChangelog";
+import { renderHookWithProviders } from "../../helpers/hook";
+
+function renderController(ready: boolean) {
+  return renderHookWithProviders(
+    ({ ready: isReady }: { ready: boolean }) => useChangelog({ ready: isReady }),
+    { initialProps: { ready } },
+  );
+}
+
+const onboarded = () => seedStorage("local", {
+  [ONBOARDING_STATE_KEY]: { completedVersion: TOUR_VERSION },
+});
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("useChangelog", () => {
+  it("suppresses the toast on a fresh install but initializes the marker", async () => {
+    // No onboarding completed => fresh install; the tour handles the welcome.
+    const { result } = renderController(true);
+    await waitFor(() =>
+      expect(readStorage("local")[CHANGELOG_STATE_KEY]).toEqual({
+        seenVersion: CHANGELOG_VERSION,
+      }),
+    );
+    expect(result.current.entry).toBeNull();
+  });
+
+  it("shows the highlights once for an already-onboarded user on the introducing release", async () => {
+    onboarded();
+    const { result } = renderController(true);
+    await waitFor(() => expect(result.current.entry).toEqual(getLatestChangelogEntry()));
+    expect(readStorage("local")[CHANGELOG_STATE_KEY]).toEqual({ seenVersion: CHANGELOG_VERSION });
+  });
+
+  it("shows when the stored seenVersion is behind", async () => {
+    seedStorage("local", { [CHANGELOG_STATE_KEY]: { seenVersion: CHANGELOG_VERSION - 1 } });
+    const { result } = renderController(true);
+    await waitFor(() => expect(result.current.entry).toEqual(getLatestChangelogEntry()));
+    expect(readStorage("local")[CHANGELOG_STATE_KEY]).toEqual({ seenVersion: CHANGELOG_VERSION });
+  });
+
+  it("stays silent when already current", async () => {
+    seedStorage("local", { [CHANGELOG_STATE_KEY]: { seenVersion: CHANGELOG_VERSION } });
+    const { result } = renderController(true);
+    await flush();
+    expect(result.current.entry).toBeNull();
+  });
+
+  it("hides the toast until ready (tour gate), then reveals it", async () => {
+    seedStorage("local", { [CHANGELOG_STATE_KEY]: { seenVersion: CHANGELOG_VERSION - 1 } });
+    const { result, rerender } = renderController(false);
+    await flush();
+    expect(result.current.entry).toBeNull();
+
+    rerender({ ready: true });
+    await waitFor(() => expect(result.current.entry).toEqual(getLatestChangelogEntry()));
+  });
+
+  it("dismiss clears the toast for good", async () => {
+    seedStorage("local", { [CHANGELOG_STATE_KEY]: { seenVersion: CHANGELOG_VERSION - 1 } });
+    const { result } = renderController(true);
+    await waitFor(() => expect(result.current.entry).not.toBeNull());
+    act(() => result.current.dismiss());
+    expect(result.current.entry).toBeNull();
+  });
+});


### PR DESCRIPTION
What's new: a version-gated (CHANGELOG_VERSION) one-time toast that floats above the composer, plus a 'What's new' panel in Settings -> About. Shows once per notable release for existing users; stays silent on fresh installs (the onboarding tour welcomes them). Per-device state in chrome.storage.local, mirroring onboarding.

Tooltips (global): only icon-only buttons show a tooltip now — text buttons no longer repeat their visible label (Button suppresses the tooltip when it has a text child). Added a 500ms hide delay in TooltipProvider so tooltips don't flicker when brushing past a trigger; re-hovering cancels the hide.

Also compacts the About 'Update check' row into the trailing slot. Tests cover the changelog storage/controller/toast and the updated Button + TooltipProvider behavior.