### PR TITLE
feat(claude): pin the pane to the account's selected workspace

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -2,6 +2,59 @@ const APP_PATH = "multi-panel/index.html";
 const CONTEXT_MENU_ID = "open-parallel-ai";
 const PENDING_MULTI_PANEL_ACTION_KEY = "pendingMultiPanelAction";
 
+// The Claude pane runs claude.ai in a cross-origin iframe whose cookie jar is
+// empty (Chrome partitions storage for embedded third-party frames), so
+// claude.ai can't read its `lastActiveOrg` cookie and defaults to the wrong
+// workspace. The browser cookie store is readable here regardless of open tabs,
+// so read that cookie and publish it to chrome.storage.local for the Claude
+// content scripts to pin to. See src/content/claude-workspace*.ts.
+const CLAUDE_WORKSPACE_STORAGE_KEY = "claudeActiveWorkspace";
+const CLAUDE_LAST_ACTIVE_ORG_COOKIE = "lastActiveOrg";
+const CLAUDE_ORG_UUID = /^[0-9a-fA-F-]{36}$/;
+
+async function readClaudeWorkspace() {
+  try {
+    const cookie = await chrome.cookies.get({
+      url: "https://claude.ai/",
+      name: CLAUDE_LAST_ACTIVE_ORG_COOKIE,
+    });
+    const value = cookie?.value;
+    return value && CLAUDE_ORG_UUID.test(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+async function publishClaudeWorkspace() {
+  const uuid = await readClaudeWorkspace();
+  if (uuid) {
+    try {
+      await chrome.storage.local.set({ [CLAUDE_WORKSPACE_STORAGE_KEY]: uuid });
+    } catch {
+      // A transient storage failure just means the pane keeps its last value.
+    }
+  }
+  return uuid;
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type === "SYNC_CLAUDE_WORKSPACE") {
+    publishClaudeWorkspace().then((uuid) => sendResponse({ uuid }));
+    return true; // keep the message channel open for the async response
+  }
+  return undefined;
+});
+
+chrome.cookies?.onChanged?.addListener((change) => {
+  const cookie = change.cookie;
+  if (
+    cookie?.name === CLAUDE_LAST_ACTIVE_ORG_COOKIE &&
+    cookie.domain.replace(/^\./, "").endsWith("claude.ai")
+  ) {
+    void publishClaudeWorkspace();
+  }
+});
+
 function getAppUrl() {
   return chrome.runtime.getURL(APP_PATH);
 }
@@ -84,6 +137,7 @@ function getSelectedTextFromContext(info) {
 
 chrome.runtime.onInstalled.addListener(async (details) => {
   await createContextMenus();
+  void publishClaudeWorkspace();
 
   // On a fresh install, open the workspace so the first-run onboarding tour
   // greets the user immediately. The tour itself decides whether to show based
@@ -96,6 +150,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
 chrome.runtime.onStartup.addListener(async () => {
   await createContextMenus();
+  void publishClaudeWorkspace();
 });
 
 chrome.action.onClicked.addListener(async () => {

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -27,12 +27,16 @@ async function readClaudeWorkspace() {
 
 async function publishClaudeWorkspace() {
   const uuid = await readClaudeWorkspace();
-  if (uuid) {
-    try {
+  try {
+    if (uuid) {
       await chrome.storage.local.set({ [CLAUDE_WORKSPACE_STORAGE_KEY]: uuid });
-    } catch {
-      // A transient storage failure just means the pane keeps its last value.
+    } else {
+      // Cookie gone or invalid (logout, cleared cookies): drop the stale pin so
+      // the pane stops forcing a workspace the user is no longer on.
+      await chrome.storage.local.remove(CLAUDE_WORKSPACE_STORAGE_KEY);
     }
+  } catch {
+    // A transient storage failure just means the pane keeps its last value.
   }
   return uuid;
 }
@@ -47,10 +51,9 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
 chrome.cookies?.onChanged?.addListener((change) => {
   const cookie = change.cookie;
-  if (
-    cookie?.name === CLAUDE_LAST_ACTIVE_ORG_COOKIE &&
-    cookie.domain.replace(/^\./, "").endsWith("claude.ai")
-  ) {
+  if (cookie?.name !== CLAUDE_LAST_ACTIVE_ORG_COOKIE) return;
+  const domain = cookie.domain.replace(/^\./, "");
+  if (domain === "claude.ai" || domain.endsWith(".claude.ai")) {
     void publishClaudeWorkspace();
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
     "storage",
     "contextMenus",
     "activeTab",
+    "cookies",
     "declarativeNetRequest",
     "declarativeNetRequestWithHostAccess"
   ],
@@ -67,10 +68,23 @@
     },
     {
       "matches": ["https://claude.ai/*"],
+      "js": ["src/content/claude-workspace.ts"],
+      "run_at": "document_start",
+      "all_frames": true,
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://claude.ai/*"],
       "js": ["src/content/claude-model-fallback.ts"],
       "run_at": "document_start",
       "all_frames": true,
       "world": "MAIN"
+    },
+    {
+      "matches": ["https://claude.ai/*"],
+      "js": ["src/content/claude-workspace-sync.ts"],
+      "run_at": "document_start",
+      "all_frames": true
     },
     {
       "matches": ["https://claude.ai/*"],

--- a/src/content/claude-workspace-sync.ts
+++ b/src/content/claude-workspace-sync.ts
@@ -1,0 +1,83 @@
+// Parallel AI — Claude workspace sync (pane side).
+//
+// See claude-workspace.ts for the full picture. The pane's cross-origin iframe
+// can't read the user's `lastActiveOrg` cookie (partitioned, empty cookie jar),
+// so it can't tell which workspace the user selected. The background service
+// worker reads that cookie from the browser cookie store (available regardless
+// of open tabs) and publishes it to chrome.storage.local. This script, running
+// in the pane's iframe, pulls that value and applies it two ways:
+//
+//  - Mirrors it into the iframe's localStorage, where claude-workspace.ts (MAIN
+//    world) reads it to rewrite the organization id on every request. This is
+//    what actually forces chat onto the selected workspace.
+//  - Best-effort, writes it back as the `lastActiveOrg` cookie before claude.ai
+//    boots, so the app can select the workspace natively (fixing the header/org
+//    label too). If the partitioned iframe blocks the cookie write, the request
+//    rewrite still keeps chat correct.
+//
+// Runs in the isolated world (needs chrome.storage / chrome.runtime) at
+// document_start.
+
+(() => {
+  if (window.top === window.self) return;
+
+  const STORAGE_KEY = "parallel-ai:claude:workspace";
+  const SYNC_KEY = "claudeActiveWorkspace";
+  const ORG_UUID = /^[0-9a-fA-F-]{36}$/;
+
+  function readLocal(): string | null {
+    try {
+      const value = localStorage.getItem(STORAGE_KEY);
+      return value && ORG_UUID.test(value) ? value : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function tryPinCookie(uuid: string) {
+    try {
+      document.cookie =
+        `lastActiveOrg=${uuid}; path=/; max-age=31536000; SameSite=None; Secure; Partitioned`;
+    } catch {
+      // Third-party cookie writes may be blocked; the request rewrite covers it.
+    }
+  }
+
+  // Runs before claude.ai boots (document_start), using the value pinned on the
+  // previous load, so the cookie is in place when the app reads it.
+  const preexisting = readLocal();
+  if (preexisting) tryPinCookie(preexisting);
+
+  function applyToIframe(uuid: unknown) {
+    if (typeof uuid !== "string" || !ORG_UUID.test(uuid)) return;
+    if (readLocal() === uuid) return;
+    try {
+      localStorage.setItem(STORAGE_KEY, uuid);
+    } catch {
+      return;
+    }
+    tryPinCookie(uuid);
+    // Re-hydrate the app against the newly pinned workspace.
+    location.reload();
+  }
+
+  // Fast path: value already published to shared storage.
+  chrome.storage.local.get(SYNC_KEY, (result) => {
+    if (chrome.runtime.lastError) return;
+    applyToIframe(result?.[SYNC_KEY]);
+  });
+
+  // Authoritative path: ask the background worker to read the current cookie.
+  chrome.runtime.sendMessage({ type: "SYNC_CLAUDE_WORKSPACE" }, (response) => {
+    if (chrome.runtime.lastError) return;
+    applyToIframe(response?.uuid);
+  });
+
+  // If the user switches workspace in a first-party tab while the pane is open,
+  // follow it live.
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === "local" && changes[SYNC_KEY]) {
+      applyToIframe(changes[SYNC_KEY].newValue);
+    }
+  });
+})();

--- a/src/content/claude-workspace-sync.ts
+++ b/src/content/claude-workspace-sync.ts
@@ -50,13 +50,16 @@
 
   function applyToIframe(uuid: unknown) {
     if (typeof uuid !== "string" || !ORG_UUID.test(uuid)) return;
-    if (readLocal() === uuid) return;
+    // Normalize casing so a case-only difference between sources can't force a
+    // needless reload. The MAIN-world rewrite also compares case-insensitively.
+    const normalized = uuid.toLowerCase();
+    if (readLocal() === normalized) return;
     try {
-      localStorage.setItem(STORAGE_KEY, uuid);
+      localStorage.setItem(STORAGE_KEY, normalized);
     } catch {
       return;
     }
-    tryPinCookie(uuid);
+    tryPinCookie(normalized);
     // Re-hydrate the app against the newly pinned workspace.
     location.reload();
   }

--- a/src/content/claude-workspace-sync.ts
+++ b/src/content/claude-workspace-sync.ts
@@ -15,6 +15,9 @@
 //    label too). If the partitioned iframe blocks the cookie write, the request
 //    rewrite still keeps chat correct.
 //
+// On logout / cookie clear the service worker removes the published value; this
+// script then drops the local pin so it stops forcing a stale workspace.
+//
 // Runs in the isolated world (needs chrome.storage / chrome.runtime) at
 // document_start.
 
@@ -24,6 +27,10 @@
   const STORAGE_KEY = "parallel-ai:claude:workspace";
   const SYNC_KEY = "claudeActiveWorkspace";
   const ORG_UUID = /^[0-9a-fA-F-]{36}$/;
+
+  // Set once we trigger a reload so the fast path and the authoritative path
+  // can't each fire location.reload() on the same load.
+  let reloading = false;
 
   function readLocal(): string | null {
     try {
@@ -43,12 +50,29 @@
     }
   }
 
+  function clearPin() {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // localStorage can be unavailable in some iframe contexts.
+    }
+    // Expire our partitioned cookie too, so a stale workspace isn't re-selected
+    // natively on the next load.
+    try {
+      document.cookie =
+        "lastActiveOrg=; path=/; max-age=0; SameSite=None; Secure; Partitioned";
+    } catch {
+      // ignore
+    }
+  }
+
   // Runs before claude.ai boots (document_start), using the value pinned on the
   // previous load, so the cookie is in place when the app reads it.
   const preexisting = readLocal();
   if (preexisting) tryPinCookie(preexisting);
 
   function applyToIframe(uuid: unknown) {
+    if (reloading) return;
     if (typeof uuid !== "string" || !ORG_UUID.test(uuid)) return;
     // Normalize casing so a case-only difference between sources can't force a
     // needless reload. The MAIN-world rewrite also compares case-insensitively.
@@ -61,6 +85,7 @@
     }
     tryPinCookie(normalized);
     // Re-hydrate the app against the newly pinned workspace.
+    reloading = true;
     location.reload();
   }
 
@@ -76,11 +101,16 @@
     applyToIframe(response?.uuid);
   });
 
-  // If the user switches workspace in a first-party tab while the pane is open,
-  // follow it live.
+  // Follow live changes. A string newValue means the user switched workspace in
+  // a first-party tab; a removed key (undefined newValue) means logout / cookie
+  // clear, so drop the local pin instead of ignoring it.
   chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === "local" && changes[SYNC_KEY]) {
-      applyToIframe(changes[SYNC_KEY].newValue);
+    if (area !== "local" || !(SYNC_KEY in changes)) return;
+    const newValue = changes[SYNC_KEY].newValue;
+    if (typeof newValue === "string") {
+      applyToIframe(newValue);
+    } else {
+      clearPin();
     }
   });
 })();

--- a/src/content/claude-workspace.ts
+++ b/src/content/claude-workspace.ts
@@ -1,0 +1,77 @@
+// Parallel AI — Claude workspace pinning (request side).
+//
+// The pane loads claude.ai in a cross-origin iframe whose cookie jar is empty
+// (Chrome partitions storage for embedded third-party frames), so claude.ai
+// can't read its `lastActiveOrg` cookie and falls back to the FIRST
+// organization in the account — often the wrong one, with no in-pane switcher
+// to change it.
+//
+// claude-workspace-sync.ts (isolated world) captures the workspace the user
+// selected in a first-party claude.ai tab and mirrors it into this iframe's
+// localStorage. This script reads that value and rewrites the organization id
+// on every /api/organizations/<id>/ request, so all reads and sends run against
+// the selected workspace regardless of what claude.ai defaults to. Runs in the
+// MAIN world at document_start so the patch is in place before claude.ai issues
+// its first API call.
+
+(() => {
+  if (window.top === window.self) return;
+
+  const STORAGE_KEY = "parallel-ai:claude:workspace";
+  const MARKER = "__parallelAiClaudeWorkspacePatched";
+  const UUID = /^[0-9a-fA-F-]{36}$/;
+  const ORG_PATH = /^\/api\/organizations\/([0-9a-fA-F-]{36})(\/.*|)$/;
+
+  const patchedWindow = window as Window &
+    typeof globalThis & { [MARKER]?: boolean };
+  if (patchedWindow[MARKER]) return;
+  patchedWindow[MARKER] = true;
+
+  function readChosen(): string | null {
+    try {
+      const value = localStorage.getItem(STORAGE_KEY);
+      return value && UUID.test(value) ? value : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const chosen = readChosen();
+  // Nothing synced yet — leave claude.ai's own default untouched.
+  if (!chosen) return;
+  const pinned: string = chosen;
+
+  function rewrite(rawUrl: string): string | null {
+    let url: URL;
+    try {
+      url = new URL(rawUrl, location.href);
+    } catch {
+      return null;
+    }
+    if (url.origin !== location.origin) return null;
+    const match = url.pathname.match(ORG_PATH);
+    if (!match) return null;
+    if (match[1].toLowerCase() === pinned.toLowerCase()) return null;
+    url.pathname = `/api/organizations/${pinned}${match[2]}`;
+    return url.toString();
+  }
+
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = function patchedFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) {
+    try {
+      if (typeof input === "string" || input instanceof URL) {
+        const next = rewrite(input.toString());
+        if (next) return nativeFetch(next, init);
+      } else if (input instanceof Request) {
+        const next = rewrite(input.url);
+        if (next) return nativeFetch(new Request(next, input), init);
+      }
+    } catch {
+      // A rewrite failure must never break the underlying request.
+    }
+    return nativeFetch(input, init);
+  };
+})();

--- a/tests/setup/chrome-mock.ts
+++ b/tests/setup/chrome-mock.ts
@@ -15,6 +15,7 @@ interface ChromeMockState {
       sendResponse: (response?: unknown) => void,
     ) => boolean | void
   >;
+  cookieListeners: Set<(change: chrome.cookies.CookieChangeInfo) => void>;
 }
 
 const state: ChromeMockState = {
@@ -25,6 +26,7 @@ const state: ChromeMockState = {
   },
   storageListeners: new Set(),
   runtimeMessageListeners: new Set(),
+  cookieListeners: new Set(),
 };
 
 function createStorageArea(area: StorageArea): chrome.storage.StorageArea {
@@ -221,6 +223,17 @@ export function installChromeMock(): void {
         Promise.resolve({ permissions: [], origins: [] }),
       ),
     },
+    cookies: {
+      get: vi.fn(() => Promise.resolve(null)),
+      getAll: vi.fn(() => Promise.resolve([])),
+      set: vi.fn(() => Promise.resolve(null)),
+      remove: vi.fn(() => Promise.resolve(null)),
+      onChanged: {
+        addListener: vi.fn((listener) => state.cookieListeners.add(listener)),
+        removeListener: vi.fn((listener) => state.cookieListeners.delete(listener)),
+        hasListener: vi.fn((listener) => state.cookieListeners.has(listener)),
+      },
+    },
     scripting: {
       executeScript: vi.fn(() => Promise.resolve([{ result: undefined }])),
     },
@@ -237,6 +250,7 @@ export function resetChromeMock(): void {
   state.storage.session.clear();
   state.storageListeners.clear();
   state.runtimeMessageListeners.clear();
+  state.cookieListeners.clear();
   if (globalThis.chrome?.runtime) {
     globalThis.chrome.runtime.lastError = null;
   }
@@ -270,4 +284,10 @@ export function emitRuntimeMessage(
     });
   }
   return responses;
+}
+
+export function emitCookieChange(change: chrome.cookies.CookieChangeInfo): void {
+  for (const listener of state.cookieListeners) {
+    listener(change);
+  }
 }

--- a/tests/unit/manifest-guardrails.test.ts
+++ b/tests/unit/manifest-guardrails.test.ts
@@ -44,7 +44,7 @@ describe("manifest guardrails", () => {
     }
   });
 
-  it("only runs the narrow model fallback in Claude MAIN world", () => {
+  it("only runs the narrow workspace + model fallback scripts in Claude MAIN world", () => {
     const claudeEntries = manifest.content_scripts.filter((entry) =>
       entry.matches.some((match) => match.includes("claude.ai")),
     );
@@ -53,7 +53,10 @@ describe("manifest guardrails", () => {
       claudeEntries
         .filter((entry) => entry.world === "MAIN")
         .flatMap((entry) => entry.js),
-    ).toEqual(["src/content/claude-model-fallback.ts"]);
+    ).toEqual([
+      "src/content/claude-workspace.ts",
+      "src/content/claude-model-fallback.ts",
+    ]);
   });
 
   it("ships bypass header rules for core iframe providers", () => {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -3,7 +3,14 @@ import path from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { readStorage } from "../setup/chrome-mock";
+import {
+  emitCookieChange,
+  emitRuntimeMessage,
+  readStorage,
+} from "../setup/chrome-mock";
+
+const PREMIUM_ORG = "02812373-138d-4a58-874b-33e46fa50871";
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 const SW_PATH = path.resolve("background", "service-worker.js");
 const SW_SOURCE = `${readFileSync(SW_PATH, "utf8")}\n//# sourceURL=file://${SW_PATH.replace(/\\/g, "/")}\n`;
@@ -171,6 +178,51 @@ describe("background service worker", () => {
       menuItemId: "some-other-id",
     } as never);
     expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
+  it("publishes the Claude workspace from the lastActiveOrg cookie on install", async () => {
+    chrome.cookies.get = vi.fn(() =>
+      Promise.resolve({ value: PREMIUM_ORG }),
+    ) as never;
+    await listeners.onInstalled[0]!({ reason: "update" });
+    await flushAsync();
+    expect(readStorage("local").claudeActiveWorkspace).toBe(PREMIUM_ORG);
+  });
+
+  it("responds to SYNC_CLAUDE_WORKSPACE and publishes the workspace", async () => {
+    chrome.cookies.get = vi.fn(() =>
+      Promise.resolve({ value: PREMIUM_ORG }),
+    ) as never;
+    const responses = emitRuntimeMessage({ type: "SYNC_CLAUDE_WORKSPACE" });
+    await flushAsync();
+    expect(responses).toContainEqual({ uuid: PREMIUM_ORG });
+    expect(readStorage("local").claudeActiveWorkspace).toBe(PREMIUM_ORG);
+  });
+
+  it("re-publishes when the lastActiveOrg cookie changes", async () => {
+    chrome.cookies.get = vi.fn(() =>
+      Promise.resolve({ value: PREMIUM_ORG }),
+    ) as never;
+    emitCookieChange({
+      removed: false,
+      cause: "explicit",
+      cookie: { name: "lastActiveOrg", domain: ".claude.ai" },
+    } as never);
+    await flushAsync();
+    expect(readStorage("local").claudeActiveWorkspace).toBe(PREMIUM_ORG);
+  });
+
+  it("ignores cookie changes for other cookies", async () => {
+    chrome.cookies.get = vi.fn(() =>
+      Promise.resolve({ value: PREMIUM_ORG }),
+    ) as never;
+    emitCookieChange({
+      removed: false,
+      cause: "explicit",
+      cookie: { name: "sessionKeyLC", domain: ".claude.ai" },
+    } as never);
+    await flushAsync();
+    expect(readStorage("local").claudeActiveWorkspace).toBeUndefined();
   });
 
   it("falls back to local storage when session storage throws", async () => {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -7,6 +7,7 @@ import {
   emitCookieChange,
   emitRuntimeMessage,
   readStorage,
+  seedStorage,
 } from "../setup/chrome-mock";
 
 const PREMIUM_ORG = "02812373-138d-4a58-874b-33e46fa50871";
@@ -210,6 +211,27 @@ describe("background service worker", () => {
     } as never);
     await flushAsync();
     expect(readStorage("local").claudeActiveWorkspace).toBe(PREMIUM_ORG);
+  });
+
+  it("clears the stored workspace when the cookie is gone", async () => {
+    seedStorage("local", { claudeActiveWorkspace: PREMIUM_ORG });
+    chrome.cookies.get = vi.fn(() => Promise.resolve(null)) as never;
+    await listeners.onInstalled[0]!({ reason: "update" });
+    await flushAsync();
+    expect(readStorage("local").claudeActiveWorkspace).toBeUndefined();
+  });
+
+  it("ignores lastActiveOrg changes on look-alike domains", async () => {
+    chrome.cookies.get = vi.fn(() =>
+      Promise.resolve({ value: PREMIUM_ORG }),
+    ) as never;
+    emitCookieChange({
+      removed: false,
+      cause: "explicit",
+      cookie: { name: "lastActiveOrg", domain: "notclaude.ai" },
+    } as never);
+    await flushAsync();
+    expect(readStorage("local").claudeActiveWorkspace).toBeUndefined();
   });
 
   it("ignores cookie changes for other cookies", async () => {


### PR DESCRIPTION
## Problem

The Claude pane loads claude.ai in a cross-origin iframe. Chrome partitions storage for embedded third-party frames, so the iframe's cookie jar is empty and claude.ai can't read its `lastActiveOrg` cookie. It falls back to the first organization in the account, and its workspace switcher is unmounted in iframe mode. On multi-workspace accounts the pane can get stuck on the wrong workspace (for example a zero-limit enterprise seat), with sends failing "Request sent to your admin" and no way to fix it in-pane.

## Fix

Follow the workspace the user selected in claude.ai, with no extra UI. Three layers, degrading gracefully:

1. `background/service-worker.js` reads the `lastActiveOrg` cookie via the `chrome.cookies` API (the cookie store is readable regardless of open tabs) and publishes it to `chrome.storage.local`, refreshing on `cookies.onChanged` and on a message from the pane.
2. `src/content/claude-workspace-sync.ts` (isolated world) pulls that value in the pane iframe, mirrors it into the iframe's `localStorage`, and writes it back as a partitioned `lastActiveOrg` cookie before claude.ai boots so the app selects the workspace natively (header/org label included). Follows live switches via `storage.onChanged`.
3. `src/content/claude-workspace.ts` (MAIN world) rewrites the organization id on every `/api/organizations/<id>/` request as a guaranteed fallback, so chat runs against the selected workspace even if the cookie write is blocked.

Adds the `cookies` permission (scoped to claude.ai via existing host permissions).

## Testing

- `tsc --noEmit` clean, full unit suite green (643 tests, including 4 new service-worker tests for the cookie sync).
- Verified in-browser: chat runs on the selected workspace, the header/org banner shows it, and switching workspace in a first-party tab updates the open pane live.
