### PR TITLE
feat(onboarding): add a usage meter tour step and illustrate the changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ It works directly through your existing accounts with each provider — no middl
 | **Connector overlay**  | Animated SVG connectors visualize fill → submit → settle for each provider.                                                                                                                                                                                                      |
 | **Attachments**        | Drag, drop, or paste images / PDFs / text files; forwarded to each provider's uploader.                                                                                                                                                                                            |
 | **Scroll sync**        | Percentage-based scroll syncing across iframes, opt-in.                                                                                                                                                                                                                            |
+| **Usage meter**        | A floating dashboard mirroring each provider's own plan limits, plus a slim usage bar at the bottom of every panel. See [Usage meter](#usage-meter).                                                                                                                                |
 | **Temporary chat**     | One-click toggle for incognito/temporary modes on supported providers.                                                                                                                                                                                                             |
 | **Prompt library**     | IndexedDB-backed prompts with variables, search, favorites, import/export.                                                                                                                                                                                                         |
 | **Theming**            | Dark, light, or auto (follows your OS preference) — the composer and panel chrome switch with the rest of the UI.                                                                                                                                                                 |
@@ -91,6 +92,30 @@ It works directly through your existing accounts with each provider — no middl
 This list is growing — suggestions for new providers are welcome. Open an issue or PR if there's a chatbot you'd like to see added.
 
 You stay logged in directly with each provider — Parallel AI never sees credentials or message contents.
+
+---
+
+## Usage meter
+
+Open it from the gauge button on the composer bar. It shows each provider's **own** reported plan usage side by side, so you can see which limit you are about to hit without opening five settings pages.
+
+| Provider | What it reports | Where it comes from |
+| --- | --- | --- |
+| Claude    | Current session, all models, and per-model limits | `claude.ai` usage endpoint |
+| ChatGPT   | Weekly usage remaining                            | ChatGPT's own rate-limit response |
+| Gemini    | Weekly limit and current usage                    | `gemini.google.com/usage` |
+| Grok      | Per-model request counts (e.g. Grok 4 reasoning)  | Grok's rate-limit endpoint |
+| Kimi      | Subscription usage                                | Kimi's subscription stats call |
+
+Providers not listed here simply show nothing — there is no estimate or token counting. Every number is the provider's own, read from the page you are already signed into.
+
+Details:
+
+- **Nothing is computed by the extension.** It never counts tokens or guesses. If a provider does not publish a number, no number is shown.
+- **Nothing leaves your browser.** Snapshots live in `chrome.storage.local` under one key per provider.
+- **Stale data hides itself.** The per-panel bar disappears rather than showing an expired figure.
+- **The panel is yours to arrange.** Drag, resize, maximize, switch between grid and list view, zoom the contents, and optionally color each bar with the provider's brand color. Size and position persist across tabs and restarts; open/maximized state is per tab.
+- **The per-panel bar is on by default** and can be switched off from the toggle in the usage panel header.
 
 ---
 
@@ -180,6 +205,18 @@ classDiagram
     +composerOffset: ComposerOffset
     +composerSize: ComposerSize
     +defaultComposerPosition: ComposerDefaultPosition
+    +paneUsageStripEnabled: bool
+    +usageColorfulBarsEnabled: bool
+    +usageViewMode: UsageViewMode
+    +usageContentZoom: number
+    +tokenMeterOffset: ComposerOffset
+    +tokenMeterSize: ComposerSize
+  }
+
+  class UsageViewMode {
+    <<enumeration>>
+    grid
+    list
   }
 
   class ThemePreference {
@@ -432,6 +469,7 @@ Vitest runs against the `src/shared/lib/*` modules with `happy-dom` and `fake-in
 - Provider sites change their DOMs frequently; selectors in `content-scripts/text-injection-*.js` and `content-scripts/enter-behavior-*.js` may need touch-ups when that happens.
 - Some providers occasionally refuse iframing despite header stripping; reload the panel from the panel header if a provider fails to load.
 - Temporary-chat support is provider-dependent (currently ChatGPT, Claude, Gemini, Grok, Qwen).
+- Usage reporting is provider-dependent (currently Claude, ChatGPT, Gemini, Grok, Kimi) and depends on endpoints the providers do not document, so a provider can stop reporting without notice. Panels with no usage data show nothing rather than an estimate.
 
 ---
 

--- a/docs/CHROME_STORE_SUBMISSION.md
+++ b/docs/CHROME_STORE_SUBMISSION.md
@@ -16,7 +16,7 @@ Parallel AI
 
 > ⚠ The Summary field is **read-only** in the CWS dev console — it's pulled from `_locales/en/messages.json` → `extensionDescription` at upload time. To change it, edit that file, bump the manifest version, rebuild, and re-upload a new package.
 
-Currently shipped in v1.0.1:
+Currently shipped in v1.0.6:
 
 ```
 Compare AI assistants side by side in one window. Send one prompt and review responses faster.
@@ -38,6 +38,7 @@ WHAT IT DOES
 • A floating composer at the bottom. Type once, send to every active panel.
 • Drag, drop, or paste files. They are forwarded to each provider's native uploader.
 • Synchronize scrolling across panels so long answers stay roughly aligned.
+• A usage meter that mirrors each provider's own published plan limits side by side, so you can see which limit you are close to. Nothing is estimated or counted by the extension.
 • A personal prompt library with variables, categories, favorites, search, and import/export.
 • Right-click any page and pick "Pre-fill this in Parallel AI" to send the selection or link into a new comparison.
 • Temporary or incognito chat on providers that support it.
@@ -118,12 +119,12 @@ No other network behavior is modified.
 
 #### Host permission justification (covers `host_permissions` + `optional_host_permissions`)
 
-The Chrome Web Store has a single "Host permission justification" field that applies to **both** the static `host_permissions` array (each AI provider domain) and the runtime `optional_host_permissions: ["<all_urls>"]`. Paste this combined block (~965 chars, fits the 1,000-char field limit):
+The Chrome Web Store has a single "Host permission justification" field that applies to **both** the static `host_permissions` array (each AI provider domain) and the runtime `optional_host_permissions: ["<all_urls>"]`. Paste this combined block (~995 chars, fits the 1,000-char field limit — re-count it if you add a host):
 
 ```
-host_permissions: 9 AI chat domains (chatgpt.com, claude.ai, gemini.google.com, grok.com, chat.deepseek.com, kimi.com, chat.qwen.ai, meta.ai, www.google.com) embedded as iframe panels for comparison, plus claudemcpcontent.com (Anthropic's CDN serving Claude's MCP show_widget iframes). Each is required so (1) the per-provider content script can drive input/upload/scroll, and (2) declarativeNetRequest rules can strip iframe-blocking response headers on that host. gator.volces.com is a Kimi tracking endpoint, listed so network rules can block it inside the Kimi panel.
+host_permissions: 9 AI chat services embedded as iframe panels (13 patterns; several serve both apex and www): chatgpt.com, chat.openai.com, claude.ai, gemini.google.com, grok.com, chat.deepseek.com, kimi.com, www.kimi.com, chat.qwen.ai, meta.ai, www.meta.ai, google.com, www.google.com. Each is needed so (1) the per-provider content script can drive input/upload/scroll and (2) declarativeNetRequest rules can strip iframe-blocking response headers there. Plus claudemcpcontent.com (Anthropic's CDN serving Claude's MCP show_widget iframes) and gator.volces.com (a Kimi tracking endpoint, listed so rules can block it inside the Kimi panel).
 
-optional_host_permissions ["<all_urls>"] is NOT granted at install. It is requested at runtime ONLY when the user explicitly right-clicks an image and chooses "Pre-fill this in Parallel AI" to attach the image to the composer. Images on the open web come from unbounded CDNs, so pre-declaring every host is impossible. Gated on a context-menu user gesture (background/service-worker.js).
+optional_host_permissions ["<all_urls>"] is NOT granted at install. It is requested at runtime ONLY when the user right-clicks an image and picks "Pre-fill this in Parallel AI" to attach it to the composer. Web images come from unbounded CDNs, so pre-declaring every host is impossible. Gated on a context-menu gesture (background/service-worker.js).
 ```
 
 #### Remote code
@@ -173,8 +174,9 @@ Pick the 5 strongest screenshots for the listing. Recommended order:
 
 ## Final pre-submission checks
 
-- [ ] `manifest.json` version bumped to `1.0.0`
+- [ ] `manifest.json` version bumped for this release (currently `1.0.6`)
 - [ ] `data/version-info.json` updated to match (or wired into the build)
+- [ ] `rules/bypass-headers.json` contains no dev-only rules — the DNR justification above states the rules apply only to the listed provider domains, so anything like `http://localhost:3000/*` must be removed before submitting
 - [ ] `bun run build` completed without errors
 - [ ] `dist/` walked through in a fresh Chrome profile — golden path works
 - [ ] No `console.log` in `dist/` JS (`grep -r "console.log" dist/`)

--- a/docs/EDGE_STORE_SUBMISSION.md
+++ b/docs/EDGE_STORE_SUBMISSION.md
@@ -30,7 +30,7 @@ You'll move through these sections in order. Save as you go — it autosaves dra
 Upload the same ZIP you submitted to CWS:
 
 ```
-parallel-ai-v1.0.1.zip   (or whatever the current built artifact is)
+parallel-ai-v1.0.6.zip   (or whatever the current built artifact is)
 ```
 
 Edge accepts CRX3 packages (regular MV3 extension ZIPs). Static analysis usually completes within ~5 minutes.
@@ -83,6 +83,7 @@ WHAT IT DOES
 • A floating composer at the bottom. Type once, send to every active panel.
 • Drag, drop, or paste files. They are forwarded to each provider's native uploader.
 • Synchronize scrolling across panels so long answers stay roughly aligned.
+• A usage meter that mirrors each provider's own published plan limits side by side, so you can see which limit you are close to. Nothing is estimated or counted by the extension.
 • A personal prompt library with variables, categories, favorites, search, and import/export.
 • Right-click any page and pick "Pre-fill this in Parallel AI" to send the selection or link into a new comparison.
 • Temporary or incognito chat on providers that support it.
@@ -164,7 +165,7 @@ activeTab — When the user invokes the "Pre-fill this in Parallel AI" context m
 
 declarativeNetRequest + declarativeNetRequestWithHostAccess — The extension's core functionality is to embed each AI chat service as an iframe panel for side-by-side comparison. Several of the supported providers send X-Frame-Options or Content-Security-Policy: frame-ancestors response headers that block iframing. The declarativeNetRequest rules in rules/bypass-headers.json strip those two response headers ONLY on sub_frame requests to the listed AI provider domains, and ONLY for those domains — not for any other site. The host-access variant is required because removing response headers on a sub-frame triggers the browser's host-access check for those specific hosts. No other network behavior is modified.
 
-host_permissions — 9 AI provider domains (chatgpt.com, claude.ai, gemini.google.com, grok.com, chat.deepseek.com, kimi.com, chat.qwen.ai, meta.ai, www.google.com) — the chat services embedded as iframe panels for comparison. Each is required so the per-provider content script can drive that provider's input/upload/scroll, and so declarativeNetRequest rules can strip iframe-blocking response headers on that host. gator.volces.com is a Kimi tracking endpoint, listed so network rules can block it inside the Kimi panel.
+host_permissions — 9 AI provider services embedded as iframe panels for comparison, declared as 13 host patterns because several serve both apex and www forms: chatgpt.com, chat.openai.com, claude.ai, gemini.google.com, grok.com, chat.deepseek.com, kimi.com, www.kimi.com, chat.qwen.ai, meta.ai, www.meta.ai, google.com, www.google.com. Each is required so the per-provider content script can drive that provider's input/upload/scroll, and so declarativeNetRequest rules can strip iframe-blocking response headers on that host. Two supporting hosts complete the list: claudemcpcontent.com (Anthropic's CDN serving Claude's MCP show_widget iframes) and gator.volces.com (a Kimi tracking endpoint, listed so network rules can block it inside the Kimi panel).
 
 optional_host_permissions ["<all_urls>"] — NOT granted at install. It is requested at runtime ONLY when the user explicitly right-clicks an image and chooses "Pre-fill this in Parallel AI" to attach the image to the composer. Images on the open web come from unbounded CDNs, so pre-declaring every host is impossible. Gated on a context-menu user gesture (background/service-worker.js).
 ```
@@ -254,9 +255,10 @@ Same ZIP, two uploads. Each store reviews independently — versions don't have 
 ## Pre-submission checklist
 
 - [ ] Microsoft Partner Center account created and identity-verified
-- [ ] Same ZIP as CWS submission ready (`parallel-ai-v1.0.1.zip` or current)
+- [ ] Same ZIP as CWS submission ready (`parallel-ai-v1.0.6.zip` or current)
 - [ ] 300 × 300 store logo exported to `icons/store/edge-logo-300.png`
 - [ ] Existing CWS screenshots + promo tiles ready (no re-export needed)
 - [ ] Privacy policy URL resolves (already true from CWS prep)
 - [ ] Permissions justification text copied into Edge's single field
+- [ ] `rules/bypass-headers.json` contains no dev-only rules — the justification states the rules apply only to the listed provider domains, so anything like `http://localhost:3000/*` must be removed before submitting
 - [ ] Age rating questionnaire complete

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -7,7 +7,7 @@ implementation plan.
 | Feature | Status | Spec |
 | --- | --- | --- |
 | Session persistence (restore parallel chats on launch) | Shipped (v1.0.3) | [session-persistence.md](session-persistence.md) |
-| Token Meter (mirror provider usage limits) | In progress (Phase 1 implemented: Claude, ChatGPT, Gemini, Grok, Kimi) | [token-meter.md](token-meter.md) |
+| Token Meter (mirror provider usage limits) | Shipped (v1.0.6, Phase 1: Claude, ChatGPT, Gemini, Grok, Kimi) | [token-meter.md](token-meter.md) |
 
 ## Status legend
 

--- a/src/multi-panel/components/FloatingComposer.tsx
+++ b/src/multi-panel/components/FloatingComposer.tsx
@@ -333,6 +333,7 @@ export function FloatingComposer({
                 }
                 data-tooltip={t("composerTooltipTokenMeter", "Usage")}
                 data-tooltip-placement="bottom"
+                data-tour="token-meter"
                 onClick={onToggleTokenMeter}
                 type="button"
               >

--- a/src/multi-panel/components/SettingsModal.tsx
+++ b/src/multi-panel/components/SettingsModal.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/shared/lib/settings";
 import type { UpdateStatus, VersionInfo } from "@/shared/lib/version-checker";
 import { getLatestChangelogEntry } from "@/multi-panel/whats-new/changelog";
+import { TokenMeterPreview } from "@/multi-panel/whats-new/TokenMeterPreview";
 
 const LATEST_CHANGELOG = getLatestChangelogEntry();
 
@@ -801,6 +802,11 @@ export function SettingsModal({
                     <div className="mb-2 text-sm font-medium text-[hsl(var(--foreground))]">
                       v{LATEST_CHANGELOG.version}
                     </div>
+                    {LATEST_CHANGELOG.media === "token-meter" ? (
+                      <div className="mb-3">
+                        <TokenMeterPreview />
+                      </div>
+                    ) : null}
                     <ul className="space-y-2 text-sm text-[hsl(var(--foreground-muted))]">
                       {LATEST_CHANGELOG.highlights.map((highlight) => (
                         <li className="flex gap-2" key={highlight}>

--- a/src/multi-panel/onboarding/OnboardingTour.tsx
+++ b/src/multi-panel/onboarding/OnboardingTour.tsx
@@ -4,6 +4,8 @@ import { useMemo, type CSSProperties, type ReactNode } from "react";
 import { Button } from "@/shared/components/Button";
 import { Modal } from "@/shared/components/Modal";
 import { useTranslation } from "@/shared/contexts/I18nContext";
+import { useSettingsContext } from "@/shared/contexts/SettingsContext";
+import { getProviderColor, type ProviderId } from "@/shared/lib/providers";
 import type { OnboardingTourController } from "@/multi-panel/onboarding/useOnboardingTour";
 
 interface OnboardingTourProps {
@@ -114,8 +116,8 @@ function LayoutMiniPreview({ rows, cols }: { rows: number; cols: number }) {
 const GLANCE_WIDTH = 256;
 const GLANCE_BODY_HEIGHT = 72;
 
-// Shared shell for the floating "at a glance" cards (Layout step 4, Scroll-sync
-// step 7) — same surface, title, and footprint.
+// Shared shell for the floating "at a glance" cards (layout, scroll-sync, and
+// usage steps) — same surface, title, and footprint.
 function GlanceCard({
   title,
   showcase,
@@ -271,6 +273,108 @@ function ScrollSyncShowcase({ reducedMotion }: { reducedMotion: boolean }) {
           scrollDistance={tile.scrollDistance}
           thumbHeight={tile.thumbHeight}
           thumbTravel={tile.thumbTravel}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+    </GlanceCard>
+  );
+}
+
+// Mini panes for the usage step's peek, in each provider's own color. Fills
+// vary per tile and the last lands in the warning range, mirroring the real
+// strip's high-usage red. Delays stagger the load-in.
+const USAGE_HIGH_FRACTION = 0.85;
+const USAGE_TILES: { provider: ProviderId; fill: number; delay: number }[] = [
+  { provider: "gemini", fill: 24, delay: 0 },
+  { provider: "chatgpt", fill: 62, delay: 0.12 },
+  { provider: "claude", fill: 96, delay: 0.24 },
+];
+
+// One mini pane wearing the usage pill: a faint message column with the same
+// bottom-centered pill the real PanelUsageStrip renders (bar + summary text).
+function UsageTile({
+  dotColor,
+  color,
+  fill,
+  delay,
+  reducedMotion,
+}: {
+  dotColor: string;
+  color: string;
+  fill: number;
+  delay: number;
+  reducedMotion: boolean;
+}) {
+  const high = fill / 100 >= USAGE_HIGH_FRACTION;
+  const barColor = high ? "hsl(var(--danger))" : color;
+  const fillStyle = {
+    background: barColor,
+    "--usage-fill": `${fill}%`,
+    "--usage-delay": `${delay}s`,
+    ...(reducedMotion ? { width: `${fill}%` } : {}),
+  } as CSSProperties;
+  return (
+    <div
+      className="relative overflow-hidden rounded-md bg-[hsl(var(--tint-base)/0.06)] ring-1 ring-[hsl(var(--tint-ring)/0.10)]"
+      style={{ width: 64, height: 52 }}
+      data-tour-usage-tile
+    >
+      <div className="flex flex-col gap-[4px] px-[6px] py-[5px]">
+        {[80, 56, 70, 88].map((width, index) => (
+          <div
+            key={index}
+            className="h-[4px] flex-none rounded-full bg-[hsl(var(--foreground)/0.16)]"
+            style={{ width: `${width}%` }}
+          />
+        ))}
+      </div>
+      {/* Content dissolves toward the bottom so the pill reads as floating. */}
+      <div
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-[18px]"
+        style={{ background: "linear-gradient(to top, hsl(var(--surface-modal)), transparent)" }}
+      />
+      <span
+        className="absolute left-[4px] top-[4px] h-[5px] w-[5px] rounded-full"
+        style={{ background: dotColor }}
+      />
+      {/* The usage pill, scaled down from PanelUsageStrip. */}
+      <span
+        className="absolute bottom-[4px] left-1/2 flex -translate-x-1/2 items-center gap-[3px] rounded-full bg-[hsl(var(--shadow-ambient)/0.55)] px-[4px] py-[2px]"
+        data-tour-usage-pill
+      >
+        {/* Wide enough that the provider color still reads at this scale. */}
+        <span className="h-[4px] w-[32px] flex-none overflow-hidden rounded-full bg-white/25">
+          <span
+            className={`block h-full rounded-full ${reducedMotion ? "" : "onboarding-usage-fill"}`}
+            data-tour-usage-bar
+            style={fillStyle}
+          />
+        </span>
+        {/* Stand-in for the summary text, which is unreadable at this size. */}
+        <span className="h-[3px] w-[8px] flex-none rounded-full bg-white/45" />
+      </span>
+    </div>
+  );
+}
+
+// "Sneak peek" for the usage step: three mini panes each wearing the usage
+// pill, so the bottom-of-pane bar is visible before the user opens the meter.
+function UsageShowcase({ reducedMotion }: { reducedMotion: boolean }) {
+  const { t } = useTranslation();
+  const { resolvedTheme } = useSettingsContext();
+  const theme = resolvedTheme === "light" ? "light" : "dark";
+  return (
+    <GlanceCard title={t("onboardingUsagePeekTitle", "Usage meter")} showcase="usage">
+      {USAGE_TILES.map((tile) => (
+        <UsageTile
+          key={tile.provider}
+          // The pill is dark in both themes, so the bar always takes the
+          // dark-theme brand color — the light one would sink into it. The dot
+          // sits on the light tile body, so it follows the active theme.
+          color={getProviderColor(tile.provider, "dark")}
+          delay={tile.delay}
+          dotColor={getProviderColor(tile.provider, theme)}
+          fill={tile.fill}
           reducedMotion={reducedMotion}
         />
       ))}
@@ -515,6 +619,7 @@ export function OnboardingTour({ tour }: OnboardingTourProps) {
         {step.showcase === "scroll-sync" ? (
           <ScrollSyncShowcase reducedMotion={reducedMotion} />
         ) : null}
+        {step.showcase === "usage" ? <UsageShowcase reducedMotion={reducedMotion} /> : null}
 
         <div
           className="pointer-events-auto squircle rounded-[24px] border border-[hsl(var(--border-muted)/0.12)] bg-[hsl(var(--surface-modal))] p-4 shadow-[0_24px_80px_-32px_hsl(var(--shadow-ambient)/0.95)]"

--- a/src/multi-panel/onboarding/tour-steps.ts
+++ b/src/multi-panel/onboarding/tour-steps.ts
@@ -51,8 +51,10 @@ export interface TourStep {
   /** Float a small visual "sneak peek" panel above the coach-mark card.
    *  "layouts": mini previews (1×3, 2×2, 3×3) so the user gets a feel for the
    *  layout picker without opening it. "scroll-sync": three mini chat panels
-   *  whose message rows scroll together, previewing synced scrolling. */
-  showcase?: "layouts" | "scroll-sync";
+   *  whose message rows scroll together, previewing synced scrolling.
+   *  "usage": three mini panes wearing the usage pill, previewing the strip
+   *  that sits at the bottom of each pane. */
+  showcase?: "layouts" | "scroll-sync" | "usage";
   /** Side effect when the step becomes active (e.g. ensure popover closed). */
   onEnter?: (actions: TourActions) => void;
   /** Cleanup when leaving the step in any direction (e.g. close the popover). */
@@ -210,6 +212,16 @@ export function buildTourSteps(t: TranslateFn): TourStep[] {
       placement: "bottom",
       hint: t("onboardingCloseHint", "Click ✕ to close the panel"),
       advanceWhen: (ctx, baseline) => ctx.activePanelCount < baseline.activePanelCount,
+    },
+    {
+      id: "token-meter",
+      target: '[data-tour="token-meter"]',
+      title: t("onboardingUsageTitle", "Keep an eye on your limits"),
+      body: t(
+        "onboardingUsageBody",
+        "Open the usage meter to see every provider's plan limits in one place. A slim usage bar also sits at the bottom of each panel, so you can spot a limit before you hit it. Happy token maxxing!",
+      ),
+      showcase: "usage",
     },
     {
       id: "settings",

--- a/src/multi-panel/whats-new/ChangelogToast.tsx
+++ b/src/multi-panel/whats-new/ChangelogToast.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react";
 
 import { Button } from "@/shared/components/Button";
 import { useTranslation } from "@/shared/contexts/I18nContext";
+import { TokenMeterPreview } from "./TokenMeterPreview";
 import type { ChangelogController } from "./useChangelog";
 
 interface Anchor {
@@ -130,6 +131,8 @@ export function ChangelogToast({ changelog }: { changelog: ChangelogController }
           <X size={16} />
         </button>
       </div>
+
+      {entry.media === "token-meter" ? <TokenMeterPreview /> : null}
 
       <ul className="mt-3 space-y-2 text-sm text-[hsl(var(--foreground-muted))]">
         {entry.highlights.map((highlight) => (

--- a/src/multi-panel/whats-new/TokenMeterPreview.tsx
+++ b/src/multi-panel/whats-new/TokenMeterPreview.tsx
@@ -14,6 +14,10 @@ const PREVIEW_ROWS: { provider: ProviderId; name: string; label: string; percent
  * A small, drawn stand-in for the Token Meter shown in the "what's new" toast
  * and the About panel. Drawn rather than a screenshot so it follows the active
  * theme and never goes stale when the real panel changes.
+ *
+ * Hidden from assistive tech: the numbers are sample data, and the toast is a
+ * role="status" live region, so announcing them would be both misleading and
+ * noisy ahead of the actual highlights.
  */
 export function TokenMeterPreview() {
   const { resolvedTheme } = useSettingsContext();
@@ -21,6 +25,7 @@ export function TokenMeterPreview() {
 
   return (
     <div
+      aria-hidden
       className="squircle mt-3 flex gap-1.5 rounded-2xl border border-[hsl(var(--border-muted)/0.08)] bg-[hsl(var(--surface-popover)/0.5)] p-2"
       data-whats-new-preview="token-meter"
     >

--- a/src/multi-panel/whats-new/TokenMeterPreview.tsx
+++ b/src/multi-panel/whats-new/TokenMeterPreview.tsx
@@ -1,0 +1,60 @@
+import { useSettingsContext } from "@/shared/contexts/SettingsContext";
+import { getProviderColor, type ProviderId } from "@/shared/lib/providers";
+
+// High-usage rows turn red in the real meter; the Claude tile shows that state.
+const HIGH_USAGE_FRACTION = 0.85;
+
+const PREVIEW_ROWS: { provider: ProviderId; name: string; label: string; percent: number }[] = [
+  { provider: "gemini", name: "Gemini", label: "Weekly limit", percent: 6 },
+  { provider: "claude", name: "Claude", label: "All models", percent: 96 },
+  { provider: "chatgpt", name: "ChatGPT", label: "Weekly usage", percent: 60 },
+];
+
+/**
+ * A small, drawn stand-in for the Token Meter shown in the "what's new" toast
+ * and the About panel. Drawn rather than a screenshot so it follows the active
+ * theme and never goes stale when the real panel changes.
+ */
+export function TokenMeterPreview() {
+  const { resolvedTheme } = useSettingsContext();
+  const theme = resolvedTheme === "light" ? "light" : "dark";
+
+  return (
+    <div
+      className="squircle mt-3 flex gap-1.5 rounded-2xl border border-[hsl(var(--border-muted)/0.08)] bg-[hsl(var(--surface-popover)/0.5)] p-2"
+      data-whats-new-preview="token-meter"
+    >
+      {PREVIEW_ROWS.map((row) => {
+        const high = row.percent / 100 >= HIGH_USAGE_FRACTION;
+        const barColor = high ? "hsl(var(--danger))" : getProviderColor(row.provider, theme);
+        return (
+          <div
+            className="squircle flex-1 rounded-xl border border-[hsl(var(--border-muted)/0.08)] bg-[hsl(var(--surface-panel))] px-2 py-1.5"
+            key={row.provider}
+          >
+            <div className="truncate text-[9px] font-semibold leading-none text-[hsl(var(--foreground))]">
+              {row.name}
+            </div>
+            <div className="mt-1.5 flex items-baseline justify-between gap-1">
+              <span className="truncate text-[8px] leading-none text-[hsl(var(--foreground-muted))]">
+                {row.label}
+              </span>
+              <span
+                className="flex-none text-[8px] font-semibold leading-none"
+                style={high ? { color: "hsl(var(--danger))" } : undefined}
+              >
+                {row.percent}%
+              </span>
+            </div>
+            <span className="mt-1 block h-1 overflow-hidden rounded-full bg-[hsl(var(--foreground)/0.10)]">
+              <span
+                className="block h-full rounded-full"
+                style={{ background: barColor, width: `${row.percent}%` }}
+              />
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/multi-panel/whats-new/changelog.ts
+++ b/src/multi-panel/whats-new/changelog.ts
@@ -11,6 +11,8 @@ export interface ChangelogEntry {
   version: string;
   /** Short, user-facing highlights. Keep to a few lines. */
   highlights: string[];
+  /** Optional drawn illustration rendered above the highlights. */
+  media?: "token-meter";
 }
 
 // Monotonic counter bumped whenever a release adds a user-facing entry below.
@@ -23,8 +25,9 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     version: "1.0.6",
     highlights: [
-      "Token Meter: a resizable floating panel mirrors each provider's own plan limits (Claude, ChatGPT, Gemini, Grok, and Kimi). Optional per-pane usage bar can be turned on in Settings.",
+      "Token Meter: a resizable floating panel mirrors each provider's own plan limits (Claude, ChatGPT, Gemini, Grok, and Kimi). A slim usage bar now sits at the bottom of each panel too — turn it off any time in the usage panel. Happy token maxxing!",
     ],
+    media: "token-meter",
   },
   {
     version: "1.0.5",

--- a/src/shared/lib/settings.ts
+++ b/src/shared/lib/settings.ts
@@ -224,7 +224,7 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   composerSize: DEFAULT_COMPOSER_SIZE,
   defaultComposerPosition: DEFAULT_COMPOSER_POSITION,
   focusModalWidth: DEFAULT_FOCUS_MODAL_WIDTH,
-  paneUsageStripEnabled: false,
+  paneUsageStripEnabled: true,
   usageColorfulBarsEnabled: false,
   usageViewMode: "grid",
   usageContentZoom: 1,

--- a/src/shared/styles/globals.css
+++ b/src/shared/styles/globals.css
@@ -552,10 +552,35 @@ html[data-theme="light"] .brand-mark__shape {
   }
 }
 
+/* Usage peek for the onboarding "Keep an eye on your limits" glance (step 11).
+   Each bar loads up to its own --usage-fill, staggered by --usage-delay so the
+   three tiles fill in sequence rather than in lockstep. */
+.onboarding-usage-fill {
+  width: 0;
+  animation: onboarding-usage-fill 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--usage-delay, 0s);
+}
+
+@keyframes onboarding-usage-fill {
+  from {
+    width: 0;
+  }
+
+  to {
+    width: var(--usage-fill, 50%);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .onboarding-scroll-sync-track,
   .onboarding-scroll-sync-thumb {
     animation: none;
+  }
+
+  /* Skip the load-in but keep the bar at its real value. */
+  .onboarding-usage-fill {
+    animation: none;
+    width: var(--usage-fill, 50%);
   }
 }
 

--- a/tests/e2e/fixtures/onboarding-tour.spec.ts
+++ b/tests/e2e/fixtures/onboarding-tour.spec.ts
@@ -138,9 +138,18 @@ test.describe("onboarding tour", () => {
     await closeButton.click({ force: true });
     await expect.poll(() => currentLayout(page), { timeout: 10_000 }).toBe("1x3");
 
+    // --- Info step: Usage meter (with the "usage at a glance" showcase) ---
+    await expect(card(page, "token-meter")).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[data-tour-showcase="usage"]')).toBeVisible();
+    await expect(page.locator("[data-tour-usage-tile]")).toHaveCount(3);
+    // The bars load in staggered; let them settle so the shot shows real fills.
+    await page.waitForTimeout(1400);
+    await shot(page, "12-token-meter");
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
     // --- Info step: Settings ---
     await expect(card(page, "settings")).toBeVisible({ timeout: 10_000 });
-    await shot(page, "12-settings");
+    await shot(page, "13-settings");
     await page.getByRole("button", { name: "Finish", exact: true }).click();
 
     // --- Finish: confetti celebration, no modal, auto-dismisses ---
@@ -150,7 +159,7 @@ test.describe("onboarding tour", () => {
     // There is no "Get started" button — the celebration replaces the modal.
     await expect(page.getByRole("button", { name: "Get started" })).toHaveCount(0);
     await page.waitForTimeout(500); // let the confetti spread for the screenshot
-    await shot(page, "13-finish");
+    await shot(page, "14-finish");
 
     // Completion is persisted immediately on entering the celebration.
     await expect.poll(() => completedVersion(page)).toBe(TOUR_VERSION);

--- a/tests/multi-panel/onboarding/OnboardingTour.test.tsx
+++ b/tests/multi-panel/onboarding/OnboardingTour.test.tsx
@@ -57,6 +57,14 @@ const scrollSyncStep: TourStep = {
   showcase: "scroll-sync",
 };
 
+const usageStep: TourStep = {
+  id: "token-meter",
+  target: '[data-tour="token-meter"]',
+  title: "Keep an eye on your limits",
+  body: "Open the usage meter to see every provider's plan limits in one place.",
+  showcase: "usage",
+};
+
 const actionStep: TourStep = {
   id: "add-pane",
   target: '[data-tour="add-pane"]',
@@ -140,13 +148,16 @@ describe("OnboardingTour view", () => {
     }
   });
 
-  it("renders the layout and scroll-sync glances at the same fixed width", () => {
-    const base = { phase: "step" as const, stepCount: 11, targetRect: fakeRect() };
+  it("renders the layout, scroll-sync, and usage glances at the same fixed width", () => {
+    const base = { phase: "step" as const, stepCount: 12, targetRect: fakeRect() };
     const { container: layoutContainer } = renderWithProviders(
       <OnboardingTour tour={makeController({ ...base, step: layoutStep, stepIndex: 3 })} />,
     );
     const { container: scrollContainer } = renderWithProviders(
       <OnboardingTour tour={makeController({ ...base, step: scrollSyncStep, stepIndex: 6 })} />,
+    );
+    const { container: usageContainer } = renderWithProviders(
+      <OnboardingTour tour={makeController({ ...base, step: usageStep, stepIndex: 10 })} />,
     );
 
     const layoutWidth = (
@@ -155,9 +166,75 @@ describe("OnboardingTour view", () => {
     const scrollWidth = (
       scrollContainer.querySelector('[data-tour-showcase="scroll-sync"]') as HTMLElement
     ).style.width;
+    const usageWidth = (usageContainer.querySelector('[data-tour-showcase="usage"]') as HTMLElement)
+      .style.width;
 
     expect(layoutWidth).not.toBe("");
     expect(scrollWidth).toBe(layoutWidth);
+    expect(usageWidth).toBe(layoutWidth);
+  });
+
+  it("renders the usage sneak peek with three panes wearing the usage pill", () => {
+    const controller = makeController({
+      phase: "step",
+      step: usageStep,
+      stepIndex: 10,
+      stepCount: 12,
+      targetRect: fakeRect(),
+    });
+    const { container } = renderWithProviders(<OnboardingTour tour={controller} />);
+
+    expect(screen.getByText("Keep an eye on your limits")).toBeInTheDocument();
+    expect(screen.getByText("Step 11 / 12")).toBeInTheDocument();
+
+    const showcase = container.querySelector('[data-tour-showcase="usage"]') as HTMLElement;
+    expect(showcase).toBeInTheDocument();
+    expect(within(showcase).getByText("Usage meter")).toBeInTheDocument();
+    // Each pane carries the bottom pill, previewing the real on-pane strip.
+    expect(showcase.querySelectorAll("[data-tour-usage-tile]")).toHaveLength(3);
+    expect(showcase.querySelectorAll("[data-tour-usage-pill]")).toHaveLength(3);
+
+    // Bars load in staggered, each to its own fill.
+    const bars = [...showcase.querySelectorAll("[data-tour-usage-bar]")] as HTMLElement[];
+    expect(bars).toHaveLength(3);
+    for (const bar of bars) {
+      expect(bar.classList.contains("onboarding-usage-fill")).toBe(true);
+    }
+    expect(bars.map((bar) => bar.style.getPropertyValue("--usage-fill"))).toEqual([
+      "24%",
+      "62%",
+      "96%",
+    ]);
+    expect(bars.map((bar) => bar.style.getPropertyValue("--usage-delay"))).toEqual([
+      "0s",
+      "0.12s",
+      "0.24s",
+    ]);
+    // Distinct provider colors, with the over-limit tile switching to danger.
+    const colors = bars.map((bar) => bar.style.background);
+    expect(new Set(colors).size).toBe(3);
+    expect(colors[2]).toContain("--danger");
+  });
+
+  it("usage sneak peek holds the bars at their real fill under reduced motion", () => {
+    const controller = makeController({
+      phase: "step",
+      step: usageStep,
+      stepIndex: 10,
+      stepCount: 12,
+      targetRect: fakeRect(),
+      reducedMotion: true,
+    });
+    const { container } = renderWithProviders(<OnboardingTour tour={controller} />);
+
+    const showcase = container.querySelector('[data-tour-showcase="usage"]') as HTMLElement;
+    const bars = [...showcase.querySelectorAll("[data-tour-usage-bar]")] as HTMLElement[];
+    expect(bars).toHaveLength(3);
+    for (const bar of bars) {
+      // No load-in animation, but the bar still shows its value.
+      expect(bar.classList.contains("onboarding-usage-fill")).toBe(false);
+    }
+    expect(bars.map((bar) => bar.style.width)).toEqual(["24%", "62%", "96%"]);
   });
 
   it("renders the scroll-sync sneak peek with three panels scrolling together", () => {

--- a/tests/multi-panel/whats-new/ChangelogToast.test.tsx
+++ b/tests/multi-panel/whats-new/ChangelogToast.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "../../helpers/render";
@@ -48,13 +48,18 @@ describe("ChangelogToast", () => {
         changelog={{ entry: { ...entry, media: "token-meter" as const }, dismiss: vi.fn() }}
       />,
     );
-    const preview = illustrated.querySelector('[data-whats-new-preview="token-meter"]');
+    const preview = illustrated.querySelector(
+      '[data-whats-new-preview="token-meter"]',
+    ) as HTMLElement;
     expect(preview).toBeInTheDocument();
     // One mini card per provider, each with its own progress bar.
-    expect(screen.getByText("Gemini")).toBeInTheDocument();
-    expect(screen.getByText("Claude")).toBeInTheDocument();
-    expect(screen.getByText("ChatGPT")).toBeInTheDocument();
-    expect(screen.getByText("96%")).toBeInTheDocument();
+    for (const name of ["Gemini", "Claude", "ChatGPT"]) {
+      expect(within(preview).getByText(name)).toBeInTheDocument();
+    }
+    expect(within(preview).getByText("96%")).toBeInTheDocument();
+    // Sample numbers inside a role="status" live region would be announced as
+    // if they were the user's real usage, so the illustration is decorative.
+    expect(preview).toHaveAttribute("aria-hidden");
   });
 
   it("dismisses from Got it and the close button", async () => {

--- a/tests/multi-panel/whats-new/ChangelogToast.test.tsx
+++ b/tests/multi-panel/whats-new/ChangelogToast.test.tsx
@@ -37,6 +37,26 @@ describe("ChangelogToast", () => {
     expect(container.querySelector("strong")).toHaveTextContent("Session persistence");
   });
 
+  it("draws the Token Meter preview only when the entry asks for it", () => {
+    const { container: plain } = renderWithProviders(
+      <ChangelogToast changelog={{ entry, dismiss: vi.fn() }} />,
+    );
+    expect(plain.querySelector('[data-whats-new-preview="token-meter"]')).toBeNull();
+
+    const { container: illustrated } = renderWithProviders(
+      <ChangelogToast
+        changelog={{ entry: { ...entry, media: "token-meter" as const }, dismiss: vi.fn() }}
+      />,
+    );
+    const preview = illustrated.querySelector('[data-whats-new-preview="token-meter"]');
+    expect(preview).toBeInTheDocument();
+    // One mini card per provider, each with its own progress bar.
+    expect(screen.getByText("Gemini")).toBeInTheDocument();
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+    expect(screen.getByText("ChatGPT")).toBeInTheDocument();
+    expect(screen.getByText("96%")).toBeInTheDocument();
+  });
+
   it("dismisses from Got it and the close button", async () => {
     const dismiss = vi.fn();
     const { user } = renderWithProviders(<ChangelogToast changelog={{ entry, dismiss }} />);

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -46,14 +46,20 @@ describe("settings", () => {
   it("defaults and normalizes the pane usage strip field", () => {
     // The Token Meter's open/position/size are per-tab (sessionStorage), not
     // synced settings, so they no longer live here.
-    expect(DEFAULT_SETTINGS.paneUsageStripEnabled).toBe(false);
+    // On by default: the onboarding tour points the bar out, so a fresh install
+    // has to actually show it.
+    expect(DEFAULT_SETTINGS.paneUsageStripEnabled).toBe(true);
 
     expect(
       normalizeSettings({ paneUsageStripEnabled: true }).paneUsageStripEnabled,
     ).toBe(true);
+    // An explicit opt-out survives normalization.
+    expect(
+      normalizeSettings({ paneUsageStripEnabled: false }).paneUsageStripEnabled,
+    ).toBe(false);
     expect(
       normalizeSettings({ paneUsageStripEnabled: "on" as never }).paneUsageStripEnabled,
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("returns individual setting values", async () => {


### PR DESCRIPTION
Introduces the Token Meter to new users through the onboarding tour, and gives the What's New toast a visual.

## What changed

**Onboarding — new step 11 of 12**
A "Keep an eye on your limits" step sits before Settings so that stays the closer. Its glance card shows three mini panes wearing the on-pane usage pill; the bars load in staggered, each in its provider's brand color, switching to the danger red past 85% — the same threshold the real strip uses.

The bar colors are pinned to the dark-theme brand variants because the pill is dark in both themes; ChatGPT's light-theme color would sink into it. The dot above sits on the light tile body, so that one follows the active theme.

Under reduced motion the bars skip the load-in but still show their real value.

The gauge button gained a `data-tour` anchor — it had none.

**Changelog illustration**
`TokenMeterPreview` renders in the What's New toast and Settings → About, opted into by a new `media` field on `ChangelogEntry`. Drawn rather than a screenshot so it follows the theme and cannot go stale as the real panel changes.

**Behavior change**
`paneUsageStripEnabled` now defaults to `true`. The tour copy points the per-panel bar out, so a fresh install has to actually show it. Note this also switches it on for existing users who never touched the toggle — `normalizeSettings` fills missing keys from defaults. The 1.0.6 changelog entry says where to turn it off.

**Docs**
README gains a usage-meter section covering what each provider reports and where it comes from, the new settings keys, and a known-limits note that usage endpoints are undocumented and can stop working. Roadmap marks Token Meter shipped.

Store submission docs had drifted independently of this work:
- The host-permission justification claimed 9 domains; the manifest has 15. Now complete, and trimmed to 995 chars to fit the 1,000-char CWS field.
- Version references still said 1.0.1 / 1.0.0.
- Neither listing mentioned the Token Meter.
- Added a checklist item: `rules/bypass-headers.json` still contains a `http://localhost:3000/*` dev rule, which contradicts the justification text claiming provider domains only. Not removed here — that is a behavior change.

## Not changed

`TOUR_VERSION` stays at `1`, so only fresh installs get the tour. Existing users learn about the feature from the What's New toast, which they will see because 1.0.5 shipped with `CHANGELOG_VERSION=3` and 1.0.6 carries `4`.

## Verification

751 unit tests, `tsc --noEmit`, build, and both onboarding e2e specs pass locally. New tests cover the stagger values, distinct provider colors, the danger switch, the reduced-motion path, and that the changelog preview renders only when the entry opts in.