### PR TITLE
fix(rules): drop the localhost dev rule from the shipped header bypass

### DIFF
--- a/rules/bypass-headers.json
+++ b/rules/bypass-headers.json
@@ -105,20 +105,6 @@
     }
   },
   {
-    "id": 6,
-    "priority": 1,
-    "action": {
-      "type": "modifyHeaders",
-      "responseHeaders": [
-        { "header": "X-Frame-Options", "operation": "remove" }
-      ]
-    },
-    "condition": {
-      "urlFilter": "http://localhost:3000/*",
-      "resourceTypes": ["sub_frame"]
-    }
-  },
-  {
     "id": 8,
     "priority": 1,
     "action": {

--- a/tests/unit/manifest-guardrails.test.ts
+++ b/tests/unit/manifest-guardrails.test.ts
@@ -114,6 +114,36 @@ describe("manifest guardrails", () => {
     }
   });
 
+  // A rule whose host is not in host_permissions cannot fire (the extension uses
+  // declarativeNetRequestWithHostAccess), so it is dead weight at best. It also
+  // makes the store permission justification false, which claims the rules only
+  // touch the listed provider domains. A localhost:3000 rule survived here from
+  // the first prototype commit until it was caught during the 1.0.6 submission.
+  it("targets only hosts the manifest already asks permission for", () => {
+    const ruleHost = (urlFilter: string) =>
+      urlFilter
+        .replace(/^\|\|/, "")
+        .replace(/^https?:\/\//, "")
+        .split("/")[0];
+
+    // "*.example.com" in a match pattern covers the apex and any subdomain.
+    const permitted = manifest.host_permissions.map((pattern) =>
+      pattern.replace(/^\*:\/\//, "").replace(/\/\*$/, ""),
+    );
+    const covered = (host: string) =>
+      permitted.some((entry) =>
+        entry.startsWith("*.")
+          ? host === entry.slice(2) || host.endsWith(`.${entry.slice(2)}`)
+          : host === entry,
+      );
+
+    const orphans = bypassRules
+      .map((rule) => ruleHost(rule.condition.urlFilter))
+      .filter((host) => !covered(host));
+
+    expect(orphans).toEqual([]);
+  });
+
   it("keeps provider ids aligned with typed ProviderId union", () => {
     const ids = PROVIDERS.map((provider) => provider.id);
     const unique = new Set(ids);


### PR DESCRIPTION
Pre-release cleanup found ahead of tagging v1.0.6.

## The rule

`rules/bypass-headers.json` shipped an `http://localhost:3000/*` rule that stripped `X-Frame-Options` on sub-frames.

```json
{ "id": 6, "action": { "type": "modifyHeaders",
    "responseHeaders": [{ "header": "X-Frame-Options", "operation": "remove" }] },
  "condition": { "urlFilter": "http://localhost:3000/*", "resourceTypes": ["sub_frame"] } }
```

It came in with the first prototype commit (`e488f5d`), sitting between the real provider rules, and nothing has referenced it since. It is also shaped unlike its neighbours — every provider rule strips both `X-Frame-Options` and `Content-Security-Policy`, this one only the former.

## Impact

Inert in practice. `localhost` is not in `host_permissions`, and the extension uses `declarativeNetRequestWithHostAccess`, which requires host permission for the request URL before a `modifyHeaders` rule can apply. It would only start working for a user who had granted the optional `<all_urls>` permission.

Removing it matters for submission accuracy: the Chrome and Edge permission justifications both state the rules apply "ONLY on sub_frame requests to the listed AI provider domains, and ONLY for those domains — not for any other site." That was false while this rule shipped.

## Guardrail

Rather than blacklisting the string, the new test asserts every DNR rule targets a host the manifest already requests permission for, handling `*.domain` patterns covering apex plus subdomains. A rule that fails it is either dead weight or an undeclared permission.

Verified it is not vacuous: re-adding the rule fails the test with `expected [ 'localhost:3000' ] to deeply equal []`.

## Verification

752 unit tests, `tsc --noEmit`, and build all pass. Freshly built `dist/rules/bypass-headers.json` is down to 12 rules with no dev entries.