### PR TITLE
fix(usage): keep the per-pane usage strip off by default, and match Kimi's own wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Details:
 - **Nothing leaves your browser.** Snapshots live in `chrome.storage.local` under one key per provider.
 - **Stale data hides itself.** The per-panel bar disappears rather than showing an expired figure.
 - **The panel is yours to arrange.** Drag, resize, maximize, switch between grid and list view, zoom the contents, and optionally color each bar with the provider's brand color. Size and position persist across tabs and restarts; open/maximized state is per tab.
-- **The per-panel bar is on by default** and can be switched off from the toggle in the usage panel header.
+- **The per-panel bar is off by default.** Turn it on from the toggle in the usage panel header — it overlays the bottom of each pane, so it stays opt-in.
 
 ---
 

--- a/content-scripts/usage-kimi.js
+++ b/content-scripts/usage-kimi.js
@@ -32,14 +32,27 @@
     }
   }
 
+  // Kimi's API names the main balance FEATURE_OMNI, but its own quota page
+  // presents that same balance as "Total usage". Map the few features whose
+  // internal name differs from what the site shows; anything unlisted still
+  // falls through to the generic title-casing below, so new balances need no
+  // code change.
+  const FEATURE_LABELS = {
+    FEATURE_OMNI: 'Total usage',
+  };
+
   // Turn a balance's feature/type into a readable label without hardcoding any
-  // specific feature: "FEATURE_OMNI" -> "Omni". Falls back to the type or a
-  // generic word so a balance always has a name.
+  // specific feature: "FEATURE_K2_THINKING" -> "K2 Thinking". Falls back to the
+  // type or a generic word so a balance always has a name.
   function labelForBalance(node) {
     const source =
       (typeof node.feature === 'string' && node.feature) ||
       (typeof node.type === 'string' && node.type) ||
       '';
+    const known = FEATURE_LABELS[source.toUpperCase()];
+    if (known) {
+      return known;
+    }
     const cleaned = source
       .replace(/^(FEATURE|TYPE|UNIT)_/i, '')
       .replace(/_/g, ' ')

--- a/src/multi-panel/onboarding/tour-steps.ts
+++ b/src/multi-panel/onboarding/tour-steps.ts
@@ -219,7 +219,7 @@ export function buildTourSteps(t: TranslateFn): TourStep[] {
       title: t("onboardingUsageTitle", "Keep an eye on your limits"),
       body: t(
         "onboardingUsageBody",
-        "Open the usage meter to see every provider's plan limits in one place. A slim usage bar also sits at the bottom of each panel, so you can spot a limit before you hit it. Happy token maxxing!",
+        "Open the usage meter to see every provider's plan limits in one place. You can also switch on a slim usage bar at the bottom of every panel, so you spot a limit before you hit it. Happy token maxxing!",
       ),
       showcase: "usage",
     },

--- a/src/multi-panel/whats-new/changelog.ts
+++ b/src/multi-panel/whats-new/changelog.ts
@@ -25,7 +25,7 @@ export const CHANGELOG: ChangelogEntry[] = [
   {
     version: "1.0.6",
     highlights: [
-      "Token Meter: a resizable floating panel mirrors each provider's own plan limits (Claude, ChatGPT, Gemini, Grok, and Kimi). A slim usage bar now sits at the bottom of each panel too — turn it off any time in the usage panel. Happy token maxxing!",
+      "Token Meter: a resizable floating panel mirrors each provider's own plan limits (Claude, ChatGPT, Gemini, Grok, and Kimi). You can also switch on a slim usage bar at the bottom of every panel from the usage panel header. Happy token maxxing!",
     ],
     media: "token-meter",
   },

--- a/src/shared/lib/settings.ts
+++ b/src/shared/lib/settings.ts
@@ -224,7 +224,7 @@ export const DEFAULT_SETTINGS: ExtensionSettings = {
   composerSize: DEFAULT_COMPOSER_SIZE,
   defaultComposerPosition: DEFAULT_COMPOSER_POSITION,
   focusModalWidth: DEFAULT_FOCUS_MODAL_WIDTH,
-  paneUsageStripEnabled: true,
+  paneUsageStripEnabled: false,
   usageColorfulBarsEnabled: false,
   usageViewMode: "grid",
   usageContentZoom: 1,

--- a/tests/content-scripts/usage-kimi.test.ts
+++ b/tests/content-scripts/usage-kimi.test.ts
@@ -109,7 +109,8 @@ describe("usage-kimi", () => {
       expect.objectContaining({
         kind: "percent",
         id: "FEATURE_OMNI",
-        label: "Omni",
+        // Kimi's own quota page calls this balance "Total usage", not Omni.
+        label: "Total usage",
         usedPercent: 42,
         resetsAt: Date.parse("2026-08-01T08:04:29.579889Z"),
       }),
@@ -130,8 +131,10 @@ describe("usage-kimi", () => {
     await collectViaRefresh();
 
     const metrics = parentPostMessage.mock.calls[0][0].snapshot.metrics;
+    // Only features whose site wording differs are mapped; anything else still
+    // gets the generic title-cased name, so new balances need no code change.
     expect(metrics.map((metric: { label: string }) => metric.label)).toEqual([
-      "Omni",
+      "Total usage",
       "K2 Thinking",
     ]);
     expect(metrics[1]).toMatchObject({ usedPercent: 50 });

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -46,20 +46,20 @@ describe("settings", () => {
   it("defaults and normalizes the pane usage strip field", () => {
     // The Token Meter's open/position/size are per-tab (sessionStorage), not
     // synced settings, so they no longer live here.
-    // On by default: the onboarding tour points the bar out, so a fresh install
-    // has to actually show it.
-    expect(DEFAULT_SETTINGS.paneUsageStripEnabled).toBe(true);
+    // Off by default: the strip overlays the provider's own composer area, so
+    // it stays opt-in from the toggle in the usage panel header.
+    expect(DEFAULT_SETTINGS.paneUsageStripEnabled).toBe(false);
 
+    // An explicit opt-in survives normalization.
     expect(
       normalizeSettings({ paneUsageStripEnabled: true }).paneUsageStripEnabled,
     ).toBe(true);
-    // An explicit opt-out survives normalization.
     expect(
       normalizeSettings({ paneUsageStripEnabled: false }).paneUsageStripEnabled,
     ).toBe(false);
     expect(
       normalizeSettings({ paneUsageStripEnabled: "on" as never }).paneUsageStripEnabled,
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("returns individual setting values", async () => {


### PR DESCRIPTION
Two related corrections ahead of the v1.0.6 tag.

## 1. Per-pane usage strip back to off by default

Reverts the default flipped in #16. The strip overlays the bottom of each pane, directly over the provider's own composer area, so it should be opt-in rather than something that appears on every panel after an update. With the default on, `normalizeSettings` would have switched it on for every existing user who had never touched the toggle.

Three places promised the bar was already visible and would have been false. All reworded:

| Where | Now says |
| --- | --- |
| Onboarding step 11 | "You can also switch on a slim usage bar at the bottom of every panel..." |
| 1.0.6 changelog entry | "You can also switch on a slim usage bar ... from the usage panel header." |
| README usage-meter section | Documented as off by default, with where the toggle lives |

The settings test now asserts the default is `false`, that an explicit opt-in survives normalization, and that a malformed value falls back to off.

## 2. Kimi's main balance was labelled "Omni"

The collector named each balance from the API's `feature` field, so `FEATURE_OMNI` surfaced as "Omni" in the pane strip. Kimi's own quota page presents that same balance as **Total usage**, so we were disagreeing with the site we mirror. The underlying number was correct — only the name was wrong.

Adds a small map for features whose internal name differs from the site wording. Anything unlisted still falls through to the generic title-casing, so new balances (`FEATURE_K2_THINKING` -> "K2 Thinking") keep working with no code change.

## Verification

751 unit tests, `tsc --noEmit`, build, and both onboarding e2e specs pass.