### PR TITLE
feat(providers): add Z.ai support

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -47,7 +47,7 @@ These values remain in the browser's cookie/storage partitions and are used only
 | `contextMenus` | Provide a right-click "Open in Parallel AI" item to send selected page text or links into the workspace. |
 | `activeTab` | When you invoke the context menu, read the selected text or current URL from the active tab — only at that moment, only on the active tab. |
 | `cookies` | Read Claude's `lastActiveOrg` and MiMo's first-party, non-HttpOnly `xiaomichatbot_ph` so the embedded frames can retain the selected workspace/session. Only those values are mirrored locally; passwords, OTPs, HttpOnly cookies, and other cookies are not copied, and no cookie is sent to a Parallel AI server. |
-| `declarativeNetRequest` and `declarativeNetRequestWithHostAccess` | Remove response headers only when needed for embedded panels. Static provider rules remove `X-Frame-Options` and/or `Content-Security-Policy` on relevant `sub_frame` responses. MiMo authentication uses a session rule restricted to open Parallel AI workspace tab IDs; it removes only `X-Frame-Options` for `sub_frame` requests to `account.xiaomi.com`, `global.account.xiaomi.com`, and `logout.account.xiaomi.com`, and is removed when the workspace tab closes or navigates away. Unrelated tabs cannot use this exception. A separate Kimi rule blocks `https://gator.volces.com/list` requests from the panel. |
+| `declarativeNetRequest` and `declarativeNetRequestWithHostAccess` | Remove response headers only when needed for embedded panels. Static provider rules remove `X-Frame-Options` and/or `Content-Security-Policy` on relevant `sub_frame` responses. Z.ai framing and MiMo authentication use session rules restricted to open Parallel AI workspace tab IDs. They remove only `X-Frame-Options` for Z.ai and MiMo authentication sub-frames and are removed when the workspace tab closes or navigates away. Unrelated tabs cannot use these exceptions. A separate Kimi rule blocks `https://gator.volces.com/list` requests from the panel. |
 | Host permissions on provider and support domains | Required for provider content scripts and framing, MiMo authentication, Claude MCP widget iframes, and the Kimi network rule. |
 
 The extension does not transmit data to any analytics, advertising, or telemetry service.
@@ -63,6 +63,7 @@ Each AI provider iframe loads that provider's own website. Your interactions wit
 - [DeepSeek](https://chat.deepseek.com/privacy)
 - [Moonshot / Kimi](https://www.kimi.com/about/privacy)
 - [Alibaba / Qwen](https://www.alibabacloud.com/help/en/legal/latest/qwen-chat-privacy-policy)
+- [Z.ai](https://chat.z.ai/legal-agreement/privacy-policy)
 - [Xiaomi / MiMo](https://privacy.mi.com/all/en_US/)
 - [Meta AI](https://www.facebook.com/privacy/policy)
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ It works directly through your existing accounts with each provider — no middl
 | <img src="icons/providers/deepseek.png" width="20" height="20" alt="DeepSeek logo" /> &nbsp; DeepSeek           | [https://chat.deepseek.com](https://chat.deepseek.com) |
 | <img src="icons/providers/kimi.svg" width="20" height="20" alt="Kimi logo" /> &nbsp; Kimi                       | [https://www.kimi.com](https://www.kimi.com)           |
 | <img src="icons/providers/qwen.svg" width="20" height="20" alt="Qwen logo" /> &nbsp; Qwen                       | [https://chat.qwen.ai](https://chat.qwen.ai)           |
+| <img src="icons/providers/zai.svg" width="20" height="20" alt="Z.ai logo" /> &nbsp; Z.ai                        | [https://chat.z.ai](https://chat.z.ai)                 |
 | <img src="icons/providers/mimo.svg" width="20" height="20" alt="Xiaomi MiMo logo" /> &nbsp; Xiaomi MiMo   | [https://aistudio.xiaomimimo.com](https://aistudio.xiaomimimo.com) |
 | <img src="icons/providers/meta.svg" width="20" height="20" alt="Meta AI logo" /> &nbsp; Meta AI                 | [https://www.meta.ai](https://www.meta.ai)             |
 | <img src="icons/providers/google.png" width="20" height="20" alt="Google logo" /> &nbsp; Google (AI / Search)   | [https://www.google.com](https://www.google.com)       |
@@ -128,7 +129,7 @@ The extension is composed of three runtime contexts:
 2. **Service worker** (`background/service-worker.js`) — wires up the action button, context menus, and keyboard commands; bridges them to the multi-panel page via `chrome.storage.session`.
 3. **Content scripts** (`src/content/*.ts` + `content-scripts/*.js`) — injected into each provider's page (which lives inside an iframe in the multi-panel app). Responsible for text injection, file uploads, scroll-sync, focus/Enter-key behavior.
 
-`declarativeNetRequest` rules remove only the response headers needed for embedded panels (for example, `X-Frame-Options` or `Content-Security-Policy` on relevant sub-frame requests). The static provider rules live in `rules/bypass-headers.json`. MiMo's authentication exception is a session rule restricted to open Parallel AI workspace tab IDs; it removes only `X-Frame-Options` for sub-frame requests to `account.xiaomi.com`, `global.account.xiaomi.com`, and `logout.account.xiaomi.com`, and is removed when a workspace tab closes or navigates away.
+`declarativeNetRequest` rules remove only the response headers needed for embedded panels (for example, `X-Frame-Options` or `Content-Security-Policy` on relevant sub-frame requests). The static provider rules live in `rules/bypass-headers.json`. Z.ai framing and MiMo authentication use session rules restricted to open Parallel AI workspace tab IDs. They remove only `X-Frame-Options` for Z.ai sub-frames and MiMo authentication sub-frames on `account.xiaomi.com`, `global.account.xiaomi.com`, and `logout.account.xiaomi.com`, and are removed when a workspace tab closes or navigates away.
 
 ```mermaid
 flowchart TB
@@ -149,7 +150,7 @@ flowchart TB
     composer["Floating composer"]
     overlay["Connector overlay (SVG)"]
     grid["Panel grid<br/>(react-resizable-panels)"]
-    iframes[("Provider iframes<br/>chatgpt · claude · gemini · grok ·<br/>deepseek · kimi · qwen · mimo · meta · google")]
+    iframes[("Provider iframes<br/>chatgpt · claude · gemini · grok · deepseek ·<br/>kimi · qwen · zai · mimo · meta · google")]
     react --> composer
     react --> overlay
     react --> grid

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -5,8 +5,14 @@ const MIMO_COOKIE_HOST = "aistudio.xiaomimimo.com";
 const MIMO_COOKIE_ORIGIN = `https://${MIMO_COOKIE_HOST}/`;
 const MIMO_PUBLIC_AUTH_COOKIE = "xiaomichatbot_ph";
 const MIMO_AUTH_SESSION_RULE_ID = 17_001;
+const ZAI_FRAME_SESSION_RULE_ID = 17_002;
 const MIMO_AUTH_URL_REGEX =
   "^https://(account|global\\.account|logout\\.account)\\.xiaomi\\.com/";
+const ZAI_FRAME_URL_FILTER = "|https://chat.z.ai/";
+const WORKSPACE_FRAME_SESSION_RULE_IDS = [
+  MIMO_AUTH_SESSION_RULE_ID,
+  ZAI_FRAME_SESSION_RULE_ID,
+];
 const ENABLED_PROVIDERS_STORAGE_KEY = "enabledProviders";
 // Existing installs should keep the pre-MiMo default until the user opts in.
 // Keep this list explicit so adding a provider to the registry never silently
@@ -32,12 +38,13 @@ const CURRENT_ENABLED_PROVIDERS = [
   "deepseek",
   "kimi",
   "qwen",
+  "zai",
   "mimo",
   "meta",
   "google",
 ];
 
-let mimoAuthRuleUpdate = Promise.resolve();
+let workspaceFramingRuleUpdate = Promise.resolve();
 
 function isMultiPanelTabUrl(value) {
   if (typeof value !== "string") return false;
@@ -55,7 +62,50 @@ function isMultiPanelTabUrl(value) {
   }
 }
 
-function updateMiMoAuthRuleTabs(mutator) {
+function getSessionRuleTabIds(rule) {
+  return Array.isArray(rule?.condition?.tabIds)
+    ? rule.condition.tabIds.filter(
+        (tabId) => Number.isInteger(tabId) && tabId >= 0,
+      )
+    : [];
+}
+
+function buildWorkspaceFramingRules(tabIds) {
+  return [
+    {
+      id: MIMO_AUTH_SESSION_RULE_ID,
+      priority: 1,
+      action: {
+        type: "modifyHeaders",
+        responseHeaders: [
+          { header: "X-Frame-Options", operation: "remove" },
+        ],
+      },
+      condition: {
+        regexFilter: MIMO_AUTH_URL_REGEX,
+        resourceTypes: ["sub_frame"],
+        tabIds,
+      },
+    },
+    {
+      id: ZAI_FRAME_SESSION_RULE_ID,
+      priority: 1,
+      action: {
+        type: "modifyHeaders",
+        responseHeaders: [
+          { header: "X-Frame-Options", operation: "remove" },
+        ],
+      },
+      condition: {
+        urlFilter: ZAI_FRAME_URL_FILTER,
+        resourceTypes: ["sub_frame"],
+        tabIds,
+      },
+    },
+  ];
+}
+
+function updateWorkspaceFramingRuleTabs(mutator) {
   const run = async () => {
     if (
       !chrome.declarativeNetRequest?.getSessionRules ||
@@ -66,14 +116,12 @@ function updateMiMoAuthRuleTabs(mutator) {
 
     try {
       const rules = await chrome.declarativeNetRequest.getSessionRules();
-      const currentRule = rules.find(
-        (rule) => rule.id === MIMO_AUTH_SESSION_RULE_ID,
+      const currentRules = rules.filter((rule) =>
+        WORKSPACE_FRAME_SESSION_RULE_IDS.includes(rule.id),
       );
-      const currentTabIds = Array.isArray(currentRule?.condition?.tabIds)
-        ? currentRule.condition.tabIds.filter(
-            (tabId) => Number.isInteger(tabId) && tabId >= 0,
-          ).sort((left, right) => left - right)
-        : [];
+      const currentTabIds = [
+        ...new Set(currentRules.flatMap(getSessionRuleTabIds)),
+      ].sort((left, right) => left - right);
       const nextTabIds = [
         ...new Set(
           mutator(currentTabIds).filter(
@@ -82,34 +130,34 @@ function updateMiMoAuthRuleTabs(mutator) {
         ),
       ].sort((left, right) => left - right);
 
+      const rulesAreSynchronized =
+        currentRules.length === WORKSPACE_FRAME_SESSION_RULE_IDS.length &&
+        WORKSPACE_FRAME_SESSION_RULE_IDS.every((ruleId) => {
+          const rule = currentRules.find((candidate) => candidate.id === ruleId);
+          const ruleTabIds = getSessionRuleTabIds(rule).sort(
+            (left, right) => left - right,
+          );
+          return (
+            ruleTabIds.length === nextTabIds.length &&
+            ruleTabIds.every((tabId, index) => tabId === nextTabIds[index])
+          );
+        });
+
       if (
         currentTabIds.length === nextTabIds.length &&
-        currentTabIds.every((tabId, index) => tabId === nextTabIds[index])
+        currentTabIds.every((tabId, index) => tabId === nextTabIds[index]) &&
+        (nextTabIds.length === 0
+          ? currentRules.length === 0
+          : rulesAreSynchronized)
       ) {
         return true;
       }
 
       const update = {
-        removeRuleIds: currentRule ? [MIMO_AUTH_SESSION_RULE_ID] : [],
+        removeRuleIds: currentRules.map((rule) => rule.id),
       };
       if (nextTabIds.length > 0) {
-        update.addRules = [
-          {
-            id: MIMO_AUTH_SESSION_RULE_ID,
-            priority: 1,
-            action: {
-              type: "modifyHeaders",
-              responseHeaders: [
-                { header: "X-Frame-Options", operation: "remove" },
-              ],
-            },
-            condition: {
-              regexFilter: MIMO_AUTH_URL_REGEX,
-              resourceTypes: ["sub_frame"],
-              tabIds: nextTabIds,
-            },
-          },
-        ];
+        update.addRules = buildWorkspaceFramingRules(nextTabIds);
       }
 
       await chrome.declarativeNetRequest.updateSessionRules(update);
@@ -119,22 +167,52 @@ function updateMiMoAuthRuleTabs(mutator) {
     }
   };
 
-  const result = mimoAuthRuleUpdate.then(run, run);
-  mimoAuthRuleUpdate = result.then(
+  const result = workspaceFramingRuleUpdate.then(run, run);
+  workspaceFramingRuleUpdate = result.then(
     () => undefined,
     () => undefined,
   );
   return result;
 }
 
-function enableMiMoAuthFramingForTab(tabId) {
-  return updateMiMoAuthRuleTabs((tabIds) => [...tabIds, tabId]);
+function enableWorkspaceFramingForTab(tabId) {
+  return updateWorkspaceFramingRuleTabs((tabIds) => [...tabIds, tabId]);
 }
 
-function disableMiMoAuthFramingForTab(tabId) {
-  return updateMiMoAuthRuleTabs((tabIds) =>
+function disableWorkspaceFramingForTab(tabId) {
+  return updateWorkspaceFramingRuleTabs((tabIds) =>
     tabIds.filter((candidate) => candidate !== tabId),
   );
+}
+
+async function syncWorkspaceFramingRulesWithOpenTabs() {
+  if (!chrome.tabs?.query) return false;
+
+  try {
+    const tabs = await chrome.tabs.query({});
+    const tabIds = tabs.flatMap((tab) => {
+      const url = tab.url || tab.pendingUrl;
+      return typeof tab.id === "number" && isMultiPanelTabUrl(url)
+        ? [tab.id]
+        : [];
+    });
+    return updateWorkspaceFramingRuleTabs(() => tabIds);
+  } catch {
+    return false;
+  }
+}
+
+async function prepareWorkspaceFraming(sender) {
+  const tabId = sender?.tab?.id;
+  if (
+    typeof tabId !== "number" ||
+    (typeof sender?.frameId === "number" && sender.frameId !== 0) ||
+    !isMultiPanelTabUrl(sender?.url)
+  ) {
+    return { ok: false };
+  }
+
+  return { ok: await enableWorkspaceFramingForTab(tabId) };
 }
 
 async function readEnabledProviders(area) {
@@ -244,7 +322,7 @@ async function syncMiMoCookiesToFrame(sender) {
     // Install the XFO exception only for this extension-owned workspace tab.
     // A session rule is removed when the tab closes and cannot make Xiaomi
     // account pages frameable from unrelated sites.
-    if (!(await enableMiMoAuthFramingForTab(tabId))) {
+    if (!(await enableWorkspaceFramingForTab(tabId))) {
       return { supported: false, found: false, changed: false };
     }
 
@@ -359,13 +437,17 @@ async function publishClaudeWorkspace() {
   return uuid;
 }
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === "PREPARE_WORKSPACE_FRAMING") {
+    prepareWorkspaceFraming(sender).then(sendResponse);
+    return true;
+  }
   if (message?.type === "SYNC_CLAUDE_WORKSPACE") {
     publishClaudeWorkspace().then((uuid) => sendResponse({ uuid }));
     return true; // keep the message channel open for the async response
   }
   if (message?.type === "SYNC_MIMO_COOKIE_PARTITION") {
-    syncMiMoCookiesToFrame(_sender).then(sendResponse);
+    syncMiMoCookiesToFrame(sender).then(sendResponse);
     return true;
   }
   return undefined;
@@ -381,15 +463,37 @@ chrome.cookies?.onChanged?.addListener((change) => {
 });
 
 chrome.tabs?.onRemoved?.addListener((tabId) => {
-  void disableMiMoAuthFramingForTab(tabId);
+  void disableWorkspaceFramingForTab(tabId);
 });
 
-chrome.tabs?.onUpdated?.addListener((tabId, changeInfo) => {
+chrome.tabs?.onCreated?.addListener((tab) => {
   if (
-    typeof changeInfo?.url === "string" &&
-    !isMultiPanelTabUrl(changeInfo.url)
+    typeof tab?.id === "number" &&
+    isMultiPanelTabUrl(tab.pendingUrl || tab.url)
   ) {
-    void disableMiMoAuthFramingForTab(tabId);
+    void enableWorkspaceFramingForTab(tab.id);
+  }
+});
+
+chrome.tabs?.onUpdated?.addListener((tabId, changeInfo, tab) => {
+  const changedUrl =
+    typeof changeInfo?.url === "string" ? changeInfo.url : null;
+  if (changedUrl) {
+    if (isMultiPanelTabUrl(changedUrl)) {
+      void enableWorkspaceFramingForTab(tabId);
+    } else {
+      void disableWorkspaceFramingForTab(tabId);
+    }
+    return;
+  }
+
+  // Prewarm rules when restore omits changeInfo.url. The workspace readiness
+  // handshake still gates Z.ai and MiMo iframe creation on confirmed setup.
+  if (
+    changeInfo?.status === "loading" &&
+    isMultiPanelTabUrl(tab?.pendingUrl || tab?.url)
+  ) {
+    void enableWorkspaceFramingForTab(tabId);
   }
 });
 
@@ -401,11 +505,12 @@ async function openMultiPanel() {
   // Always open a fresh tab so pending actions land in a new workspace,
   // never reused into an existing one.
   const tab = await chrome.tabs.create({
-    url: getAppUrl(),
+    url: "about:blank",
     active: true,
   });
   if (typeof tab?.id === "number") {
-    await enableMiMoAuthFramingForTab(tab.id);
+    await enableWorkspaceFramingForTab(tab.id);
+    await chrome.tabs.update(tab.id, { url: getAppUrl() });
   }
 }
 
@@ -477,6 +582,7 @@ function getSelectedTextFromContext(info) {
 }
 
 chrome.runtime.onInstalled.addListener(async (details) => {
+  await syncWorkspaceFramingRulesWithOpenTabs();
   await createContextMenus();
   void publishClaudeWorkspace();
 
@@ -495,6 +601,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 });
 
 chrome.runtime.onStartup.addListener(async () => {
+  await syncWorkspaceFramingRulesWithOpenTabs();
   await createContextMenus();
   void publishClaudeWorkspace();
 });

--- a/content-scripts/enter-behavior-zai.js
+++ b/content-scripts/enter-behavior-zai.js
@@ -1,0 +1,88 @@
+// Z.ai Enter/Shift+Enter behavior swap.
+
+function createEnterEvent(modifiers = {}) {
+  return new KeyboardEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    which: 13,
+    bubbles: true,
+    cancelable: true,
+    shiftKey: modifiers.shift || false,
+    ctrlKey: modifiers.ctrl || false,
+    metaKey: modifiers.meta || false,
+    altKey: modifiers.alt || false,
+  });
+}
+
+function isZaiInput(element) {
+  return Boolean(
+    element &&
+      element.tagName === "TEXTAREA" &&
+      element.offsetParent !== null &&
+      (element.id === "chat-input" || element.closest("form")),
+  );
+}
+
+function insertTextareaNewline(textarea) {
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  const value = textarea.value;
+
+  textarea.value = `${value.substring(0, start)}\n${value.substring(end)}`;
+  textarea.selectionStart = textarea.selectionEnd = start + 1;
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  textarea.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function findSendButton() {
+  return (
+    document.querySelector("#send-message-button:not([disabled])") ||
+    document.querySelector("button.sendMessageButton:not([disabled])") ||
+    document.querySelector('form button[type="submit"]:not([disabled])')
+  );
+}
+
+function handleEnterSwap(event) {
+  if (!event.isTrusted || event.code !== "Enter" || event.isComposing) {
+    return;
+  }
+
+  const enterBehavior = window.ParallelAIEnterBehavior;
+  const enterKeyConfig = enterBehavior?.getConfig?.();
+  const matchesModifiers = enterBehavior?.matchesModifiers;
+
+  if (!enterKeyConfig || typeof matchesModifiers !== "function") {
+    return;
+  }
+
+  const activeElement = document.activeElement;
+  if (!isZaiInput(activeElement)) {
+    return;
+  }
+
+  if (matchesModifiers(event, enterKeyConfig.newlineModifiers)) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    insertTextareaNewline(activeElement);
+    return;
+  }
+
+  if (matchesModifiers(event, enterKeyConfig.sendModifiers)) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+
+    const sendButton = findSendButton();
+    if (sendButton) {
+      sendButton.click();
+    } else {
+      activeElement.dispatchEvent(createEnterEvent());
+    }
+    return;
+  }
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+}
+
+window.ParallelAIEnterBehavior?.applyEnterSwapSetting?.(handleEnterSwap);

--- a/content-scripts/file-injection.js
+++ b/content-scripts/file-injection.js
@@ -9,6 +9,7 @@
     deepseek: ['input[type="file"]'],
     kimi: ['input[type="file"]'],
     qwen: ['input[type="file"]'],
+    zai: ['input[type="file"]'],
     mimo: ['input[type="file"]'],
     meta: ['input[type="file"]'],
     google: ['input[type="file"]'],
@@ -28,6 +29,7 @@
       'button[title*="Attach"]',
       'button[title*="Upload"]',
     ],
+    zai: [],
     mimo: [
       'button[data-track-id="file_bar_upload_btn"]',
       'button[aria-label="Upload file"]',
@@ -101,6 +103,10 @@
 
     if (hostname.includes("chat.qwen.ai")) {
       return "qwen";
+    }
+
+    if (hostname === "chat.z.ai") {
+      return "zai";
     }
 
     if (hostname.includes("aistudio.xiaomimimo.com")) {

--- a/content-scripts/focus-toggle.js
+++ b/content-scripts/focus-toggle.js
@@ -58,6 +58,13 @@ function findProviderInput() {
            document.querySelector('div[contenteditable="true"]');
   }
 
+  // Z.ai
+  if (host === 'chat.z.ai') {
+    return document.querySelector('#chat-input') ||
+           document.querySelector('textarea[placeholder="How can I help you today?"]') ||
+           document.querySelector('textarea');
+  }
+
   // Xiaomi MiMo
   if (host.includes('aistudio.xiaomimimo.com')) {
     return document.querySelector('textarea[placeholder*="有问题"]') ||

--- a/content-scripts/text-injection-all-providers.js
+++ b/content-scripts/text-injection-all-providers.js
@@ -27,6 +27,7 @@
   const CHATGPT_AUTO_SUBMIT_POLL_INTERVAL_MS = 150;
   const CHATGPT_AUTO_SUBMIT_TIMEOUT_MS = 2500;
   const CHATGPT_IMAGE_AUTO_SUBMIT_TIMEOUT_MS = 12000;
+  const ZAI_IMAGE_AUTO_SUBMIT_TIMEOUT_MS = 12000;
   const MULTI_PANEL_USER_INTERACTION_TRACKING_TIMEOUT_MS = 90000;
   const PROVIDER_INPUT_ANCHOR_REPORT_DELAY_MS = 140;
   const TEMP_CHAT_POLL_INTERVAL_MS = 200;
@@ -79,6 +80,11 @@
       'div[contenteditable="true"][role="textbox"]',
       'div[contenteditable="true"]'
     ],
+    zai: [
+      '#chat-input',
+      'textarea[placeholder="How can I help you today?"]',
+      'textarea'
+    ],
     mimo: [
       'textarea[placeholder*="有问题"]',
       'textarea[placeholder*="Ask me anything"]',
@@ -122,6 +128,7 @@
     deepseek: true,
     kimi: true,  // Kimi supports images
     qwen: true,
+    zai: true,
     mimo: true,
     meta: true,
     google: true  // Google AI Mode supports images
@@ -136,6 +143,7 @@
     deepseek: ['input[type="file"]'],
     kimi: ['input[type="file"]'],
     qwen: ['input[type="file"]'],
+    zai: ['input[type="file"]'],
     mimo: ['input[type="file"]'],
     meta: ['input[type="file"]'],
     google: ['input[type="file"]']
@@ -157,6 +165,7 @@
       'button[title*="Upload"]',
       'button[type="button"]:has(input[type="file"])'
     ],
+    zai: [],
     mimo: [
       'button[data-track-id="file_bar_upload_btn"]',
       'button[aria-label="Upload file"]',
@@ -247,6 +256,11 @@
       '[role="button"][title*="send" i]',
       '[class*="send"][role="button"]',
       'form button:has(svg)'
+    ],
+    zai: [
+      '#send-message-button',
+      'button.sendMessageButton',
+      'form button[type="submit"]'
     ],
     mimo: [
       'button[data-track-id*="send" i]',
@@ -348,6 +362,12 @@
       'button[class*="stop" i]',
       'button[class*="pause" i]'
     ],
+    zai: [
+      '#stop-response-button',
+      'button[aria-label*="Stop" i]',
+      'button[title*="Stop" i]',
+      'button[class*="stop" i]'
+    ],
     meta: [
       'button[aria-label="Stop"]',
       'button[aria-label="Stop response"]',
@@ -447,6 +467,11 @@
       'a[href$="/new"]',
       'a[href*="/new?"]'
     ],
+    zai: [
+      '#sidebar-new-chat-button',
+      '#new-chat-button',
+      'button[aria-label="New Chat"]'
+    ],
     mimo: [
       'button[aria-label*="New"]',
       'button[aria-label*="新建"]',
@@ -478,6 +503,7 @@
     deepseek: 'https://chat.deepseek.com/',
     kimi: 'https://www.kimi.com/',
     qwen: 'https://chat.qwen.ai/',
+    zai: 'https://chat.z.ai/',
     mimo: 'https://aistudio.xiaomimimo.com/',
     meta: 'https://www.meta.ai/',
     google: 'https://www.google.com/search?udm=50'
@@ -532,6 +558,8 @@
       return 'kimi';
     } else if (hostname.includes('chat.qwen.ai')) {
       return 'qwen';
+    } else if (hostname === 'chat.z.ai') {
+      return 'zai';
     } else if (hostname.includes('aistudio.xiaomimimo.com')) {
       return 'mimo';
     } else if (hostname.includes('meta.ai')) {
@@ -2166,12 +2194,29 @@
       : 500;
   }
 
+  // Z.ai renders a w-60 chip immediately, but the thumbnail stays a spinner
+  // until status leaves "uploading". The send button stays enabled, so
+  // auto-submit must wait for the preview <img>, not for disabled=false.
+  function isZaiImageAttachmentReady() {
+    const input = document.querySelector('#chat-input');
+    const root = input?.closest('form') || document;
+    const chips = root.querySelectorAll('button.w-60.shrink-0');
+    if (chips.length === 0) {
+      return false;
+    }
+
+    return Array.from(chips).every((chip) => Boolean(chip.querySelector('img')));
+  }
+
   function scheduleProviderAutoSubmit(provider, providerMode = null, options = {}) {
     const delay = typeof options.delay === 'number'
       ? options.delay
       : getProviderAutoSubmitDelay(provider);
+    const waitUntil = typeof options.waitUntil === 'function' ? options.waitUntil : null;
 
-    if (provider !== 'chatgpt') {
+    const retryUntilReady = provider === 'chatgpt' || options.retryUntilReady === true || waitUntil !== null;
+
+    if (!retryUntilReady) {
       setTimeout(() => {
         const clicked = clickSendButton(provider, providerMode);
         if (!clicked) {
@@ -2187,6 +2232,16 @@
     const deadline = Date.now() + timeout;
 
     const attemptClick = () => {
+      if (waitUntil && !waitUntil()) {
+        if (Date.now() >= deadline) {
+          console.warn('[Text Injection] Failed to click send button for', provider);
+          return;
+        }
+
+        setTimeout(attemptClick, CHATGPT_AUTO_SUBMIT_POLL_INTERVAL_MS);
+        return;
+      }
+
       const clicked = clickSendButton(provider, providerMode);
       if (clicked) {
         return;
@@ -2719,6 +2774,7 @@
       }
 
       let filledDraftReady = false;
+      const waitsForImageReady = provider === 'chatgpt' || provider === 'zai';
 
       // Inject images first
       const imageInjectionInterval = getProviderImageInjectionInterval(provider);
@@ -2739,14 +2795,18 @@
         const textInjected = injectText(
           provider,
           text,
-          autoSubmit && provider === 'chatgpt' ? false : autoSubmit,
+          autoSubmit && waitsForImageReady ? false : autoSubmit,
           providerMode
         );
         filledDraftReady = filledDraftReady || textInjected;
 
-        if (autoSubmit && provider === 'chatgpt' && textInjected) {
+        if (autoSubmit && waitsForImageReady && textInjected) {
           scheduleProviderAutoSubmit(provider, providerMode, {
-            timeout: CHATGPT_IMAGE_AUTO_SUBMIT_TIMEOUT_MS,
+            timeout: provider === 'chatgpt'
+              ? CHATGPT_IMAGE_AUTO_SUBMIT_TIMEOUT_MS
+              : ZAI_IMAGE_AUTO_SUBMIT_TIMEOUT_MS,
+            retryUntilReady: true,
+            waitUntil: provider === 'zai' ? isZaiImageAttachmentReady : undefined,
           });
         }
       } else if (autoSubmit) {
@@ -2756,7 +2816,11 @@
           delay: 0,
           timeout: provider === 'chatgpt'
             ? CHATGPT_IMAGE_AUTO_SUBMIT_TIMEOUT_MS
-            : CHATGPT_AUTO_SUBMIT_TIMEOUT_MS,
+            : provider === 'zai'
+              ? ZAI_IMAGE_AUTO_SUBMIT_TIMEOUT_MS
+              : CHATGPT_AUTO_SUBMIT_TIMEOUT_MS,
+          retryUntilReady: waitsForImageReady,
+          waitUntil: provider === 'zai' ? isZaiImageAttachmentReady : undefined,
         });
       }
 

--- a/docs/CHROME_STORE_SUBMISSION.md
+++ b/docs/CHROME_STORE_SUBMISSION.md
@@ -16,7 +16,7 @@ Parallel AI
 
 > ⚠ The Summary field is **read-only** in the CWS dev console — it's pulled from `_locales/en/messages.json` → `extensionDescription` at upload time. To change it, edit that file, bump the manifest version, rebuild, and re-upload a new package.
 
-Currently shipped in v1.0.6:
+Currently shipped in v1.0.7:
 
 ```
 Compare AI assistants side by side in one window. Send one prompt and review responses faster.
@@ -119,7 +119,7 @@ Reads Claude's `lastActiveOrg` and MiMo's first-party, non-HttpOnly `xiaomichatb
 ```
 The extension's core functionality is to embed each AI chat service as an iframe panel for side-by-side comparison. Some providers send response headers that block framing.
 
-Static declarativeNetRequest rules in `rules/bypass-headers.json` remove only the response headers needed by embedded panels. Provider rules remove `X-Frame-Options` and/or `Content-Security-Policy` on relevant `sub_frame` responses. MiMo authentication uses a session rule restricted to open Parallel AI workspace tab IDs; it removes only `X-Frame-Options` for `sub_frame` requests to `https://account.xiaomi.com/*`, `https://global.account.xiaomi.com/*`, and `https://logout.account.xiaomi.com/*`. The rule is removed when a workspace tab closes or navigates away, so unrelated tabs cannot use it. A separate Kimi rule blocks `https://gator.volces.com/list` requests from the panel. The host-access variant is required because modifying response headers on a sub-frame triggers Chrome's host-access check for those specific hosts.
+Static declarativeNetRequest rules in `rules/bypass-headers.json` remove only the response headers needed by embedded panels. Provider rules remove `X-Frame-Options` and/or `Content-Security-Policy` on relevant `sub_frame` responses. Z.ai framing and MiMo authentication use session rules restricted to open Parallel AI workspace tab IDs. They remove only `X-Frame-Options` for `https://chat.z.ai/*` sub-frames and MiMo authentication sub-frames on `https://account.xiaomi.com/*`, `https://global.account.xiaomi.com/*`, and `https://logout.account.xiaomi.com/*`. The rules are removed when a workspace tab closes or navigates away, so unrelated tabs cannot use them. A separate Kimi rule blocks `https://gator.volces.com/list` requests from the panel. The host-access variant is required because modifying response headers on a sub-frame triggers Chrome's host-access check for those specific hosts.
 ```
 
 #### Host permission justification (covers `host_permissions` + `optional_host_permissions`)
@@ -127,7 +127,7 @@ Static declarativeNetRequest rules in `rules/bypass-headers.json` remove only th
 The Chrome Web Store has a single "Host permission justification" field that applies to **both** the static `host_permissions` array and the runtime `optional_host_permissions: ["<all_urls>"]`. Paste this combined block and keep it within the field's 1,000-character limit:
 
 ```
-host_permissions: 19 total host patterns — 14 provider-surface patterns for 10 chat services: *://chatgpt.com/*, *://chat.openai.com/*, *://claude.ai/*, *://gemini.google.com/*, *://grok.com/*, *://chat.deepseek.com/*, *://kimi.com/*, *://www.kimi.com/*, *://chat.qwen.ai/*, https://aistudio.xiaomimimo.com/*, *://meta.ai/*, *://www.meta.ai/*, *://google.com/*, *://www.google.com/*. Three MiMo auth patterns: https://account.xiaomi.com/*, https://global.account.xiaomi.com/*, and https://logout.account.xiaomi.com/*. Supporting patterns: *://*.claudemcpcontent.com/* (Claude MCP widgets) and *://gator.volces.com/* (Kimi network rule). Provider hosts enable content scripts and needed framing; MiMo auth hosts support embedded sign-in and sign-out.
+host_permissions: 20 total host patterns — 15 provider-surface patterns for 11 chat services: *://chatgpt.com/*, *://chat.openai.com/*, *://claude.ai/*, *://gemini.google.com/*, *://grok.com/*, *://chat.deepseek.com/*, *://kimi.com/*, *://www.kimi.com/*, *://chat.qwen.ai/*, https://chat.z.ai/*, https://aistudio.xiaomimimo.com/*, *://meta.ai/*, *://www.meta.ai/*, *://google.com/*, *://www.google.com/*. Three MiMo auth patterns: https://account.xiaomi.com/*, https://global.account.xiaomi.com/*, and https://logout.account.xiaomi.com/*. Supporting patterns: *://*.claudemcpcontent.com/* (Claude MCP widgets) and *://gator.volces.com/* (Kimi network rule). Provider hosts enable content scripts and needed framing; MiMo auth hosts support embedded sign-in and sign-out.
 
 optional_host_permissions ["<all_urls>"]: runtime-only for the explicit image context-menu action; never granted at install because image CDNs are unbounded.
 ```
@@ -181,7 +181,7 @@ Pick the 5 strongest screenshots for the listing. Recommended order:
 
 ## Final pre-submission checks
 
-- [ ] `manifest.json` version bumped for this release (currently `1.0.6`)
+- [ ] `manifest.json` version bumped for this release (currently `1.0.7`)
 - [ ] `data/version-info.json` updated to match (or wired into the build)
 - [ ] `rules/bypass-headers.json` contains no dev-only rules; verify the service worker's Xiaomi authentication session rule remains restricted to workspace tab IDs, and remove anything like `http://localhost:3000/*` before submitting
 - [ ] `bun run build` completed without errors

--- a/docs/EDGE_STORE_SUBMISSION.md
+++ b/docs/EDGE_STORE_SUBMISSION.md
@@ -30,7 +30,7 @@ You'll move through these sections in order. Save as you go — it autosaves dra
 Upload the same ZIP you submitted to CWS:
 
 ```
-parallel-ai-v1.0.6.zip   (or whatever the current built artifact is)
+parallel-ai-v1.0.7.zip   (or whatever the current built artifact is)
 ```
 
 Edge accepts CRX3 packages (regular MV3 extension ZIPs). Static analysis usually completes within ~5 minutes.
@@ -166,9 +166,9 @@ activeTab — When the user invokes the "Pre-fill this in Parallel AI" context m
 
 cookies — Reads Claude's `lastActiveOrg` and MiMo's first-party, non-HttpOnly `xiaomichatbot_ph` so embedded frames can retain the selected workspace/session. Only those values are mirrored locally into the relevant iframe partitions; the MiMo mirror is removed when its first-party cookie disappears. Passwords, one-time codes (OTP), HttpOnly cookies, and other cookies are not copied, and no cookie is sent to a Parallel AI server.
 
-declarativeNetRequest + declarativeNetRequestWithHostAccess — The extension embeds each AI chat service as an iframe panel. Some providers send response headers that block framing. Static rules in `rules/bypass-headers.json` remove only headers needed by embedded panels: provider rules remove `X-Frame-Options` and/or `Content-Security-Policy` on relevant `sub_frame` responses. MiMo authentication uses a session rule restricted to open Parallel AI workspace tab IDs; it removes only `X-Frame-Options` for `sub_frame` requests to `https://account.xiaomi.com/*`, `https://global.account.xiaomi.com/*`, and `https://logout.account.xiaomi.com/*`. The rule is removed when a workspace tab closes or navigates away, so unrelated tabs cannot use it. A separate Kimi rule blocks `https://gator.volces.com/list` requests from the panel. The host-access variant is required when modifying sub-frame response headers.
+declarativeNetRequest + declarativeNetRequestWithHostAccess — The extension embeds each AI chat service as an iframe panel. Some providers send response headers that block framing. Static rules in `rules/bypass-headers.json` remove only headers needed by embedded panels: provider rules remove `X-Frame-Options` and/or `Content-Security-Policy` on relevant `sub_frame` responses. Z.ai framing and MiMo authentication use session rules restricted to open Parallel AI workspace tab IDs. They remove only `X-Frame-Options` for `https://chat.z.ai/*` sub-frames and MiMo authentication sub-frames on `https://account.xiaomi.com/*`, `https://global.account.xiaomi.com/*`, and `https://logout.account.xiaomi.com/*`. The rules are removed when a workspace tab closes or navigates away, so unrelated tabs cannot use them. A separate Kimi rule blocks `https://gator.volces.com/list` requests from the panel. The host-access variant is required when modifying sub-frame response headers.
 
-host_permissions — 19 total host patterns — 14 provider-surface patterns for 10 chat services: *://chatgpt.com/*, *://chat.openai.com/*, *://claude.ai/*, *://gemini.google.com/*, *://grok.com/*, *://chat.deepseek.com/*, *://kimi.com/*, *://www.kimi.com/*, *://chat.qwen.ai/*, https://aistudio.xiaomimimo.com/*, *://meta.ai/*, *://www.meta.ai/*, *://google.com/*, *://www.google.com/*. Three MiMo auth patterns: https://account.xiaomi.com/*, https://global.account.xiaomi.com/*, and https://logout.account.xiaomi.com/*. Supporting patterns: *://*.claudemcpcontent.com/* (Claude MCP widgets) and *://gator.volces.com/* (Kimi network rule). Provider hosts enable content scripts and needed framing; MiMo auth hosts support embedded sign-in and sign-out.
+host_permissions — 20 total host patterns — 15 provider-surface patterns for 11 chat services: *://chatgpt.com/*, *://chat.openai.com/*, *://claude.ai/*, *://gemini.google.com/*, *://grok.com/*, *://chat.deepseek.com/*, *://kimi.com/*, *://www.kimi.com/*, *://chat.qwen.ai/*, https://chat.z.ai/*, https://aistudio.xiaomimimo.com/*, *://meta.ai/*, *://www.meta.ai/*, *://google.com/*, *://www.google.com/*. Three MiMo auth patterns: https://account.xiaomi.com/*, https://global.account.xiaomi.com/*, and https://logout.account.xiaomi.com/*. Supporting patterns: *://*.claudemcpcontent.com/* (Claude MCP widgets) and *://gator.volces.com/* (Kimi network rule). Provider hosts enable content scripts and needed framing; MiMo auth hosts support embedded sign-in and sign-out.
 
 optional_host_permissions ["<all_urls>"] — runtime-only for the explicit image context-menu action; never granted at install because image CDNs are unbounded.
 ```
@@ -260,7 +260,7 @@ Same ZIP, two uploads. Each store reviews independently — versions don't have 
 ## Pre-submission checklist
 
 - [ ] Microsoft Partner Center account created and identity-verified
-- [ ] Same ZIP as CWS submission ready (`parallel-ai-v1.0.6.zip` or current)
+- [ ] Same ZIP as CWS submission ready (`parallel-ai-v1.0.7.zip` or current)
 - [ ] 300 × 300 store logo exported to `icons/store/edge-logo-300.png`
 - [ ] Existing CWS screenshots + promo tiles ready (no re-export needed)
 - [ ] Privacy policy URL resolves (already true from CWS prep)

--- a/icons/providers/dark/zai.svg
+++ b/icons/providers/dark/zai.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+  <rect x="1.5" y="1.5" width="27" height="27" rx="4" fill="#2D2D2D" stroke="#FFFFFF" stroke-width="0.63"/>
+  <path fill="#FFFFFF" d="M15.47 7.1l-1.3 1.85c-.2.29-.54.47-.9.47h-7.1V7.1h9.3Zm8.83 0L13.14 22.91H5.7L16.86 7.1h7.44Zm-9.77 15.81 1.31-1.86c.2-.29.54-.47.9-.47h7.09v2.33h-9.3Z"/>
+</svg>

--- a/icons/providers/zai.svg
+++ b/icons/providers/zai.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30">
+  <rect x="1.5" y="1.5" width="27" height="27" rx="4" fill="#2D2D2D" stroke="#FFFFFF" stroke-width="0.63"/>
+  <path fill="#FFFFFF" d="M15.47 7.1l-1.3 1.85c-.2.29-.54.47-.9.47h-7.1V7.1h9.3Zm8.83 0L13.14 22.91H5.7L16.86 7.1h7.44Zm-9.77 15.81 1.31-1.86c.2-.29.54-.47.9-.47h7.09v2.33h-9.3Z"/>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "130",
@@ -27,6 +27,7 @@
     "*://www.kimi.com/*",
     "*://kimi.com/*",
     "*://chat.qwen.ai/*",
+    "https://chat.z.ai/*",
     "https://aistudio.xiaomimimo.com/*",
     "https://account.xiaomi.com/*",
     "https://global.account.xiaomi.com/*",
@@ -150,6 +151,12 @@
     {
       "matches": ["https://chat.qwen.ai/*"],
       "js": ["src/content/qwen.ts"],
+      "run_at": "document_start",
+      "all_frames": true
+    },
+    {
+      "matches": ["https://chat.z.ai/*"],
+      "js": ["src/content/zai.ts"],
       "run_at": "document_start",
       "all_frames": true
     },

--- a/src/content/zai.ts
+++ b/src/content/zai.ts
@@ -1,0 +1,6 @@
+import "../../content-scripts/enter-behavior-utils.js";
+import "../../content-scripts/enter-behavior-zai.js";
+import "../../content-scripts/text-injection-all-providers.js";
+import "../../content-scripts/file-injection.js";
+import "../../content-scripts/scroll-sync.js";
+import "../../content-scripts/focus-toggle.js";

--- a/src/multi-panel/App.tsx
+++ b/src/multi-panel/App.tsx
@@ -36,6 +36,7 @@ import { useProviderUsageController } from "@/multi-panel/hooks/useProviderUsage
 import { useWorkspaceUrlController } from "@/multi-panel/hooks/useWorkspaceUrlController";
 import { useVersionCheck } from "@/multi-panel/hooks/useVersionCheck";
 import { useWorkspaceDataController } from "@/multi-panel/hooks/useWorkspaceDataController";
+import { useWorkspaceFramingReady } from "@/multi-panel/hooks/useWorkspaceFramingReady";
 import { useProviderContext } from "@/shared/contexts/ProviderContext";
 import { useSettingsContext } from "@/shared/contexts/SettingsContext";
 import { useTranslation } from "@/shared/contexts/I18nContext";
@@ -59,6 +60,7 @@ import type {
 const CONNECTOR_MASK_ID = "composer-connector-mask";
 
 export function App() {
+  const workspaceFramingReady = useWorkspaceFramingReady();
   const { providers, reorderProvider, setGoogleMode, toggleProvider } = useProviderContext();
   const {
     loaded,
@@ -267,6 +269,7 @@ export function App() {
     temporaryChatEnabled,
     restoredUrlByProvider: restoredWorkspace?.urls,
     resumeEnabled: isRestoredTab,
+    workspaceFramingReady,
   });
   const {
     clearPanels,

--- a/src/multi-panel/hooks/useProviderFramesController.ts
+++ b/src/multi-panel/hooks/useProviderFramesController.ts
@@ -7,6 +7,7 @@ import type { ResolvedTheme } from "@/shared/lib/theme";
 import { getActivePanelProviders, getPanelUrl } from "@/multi-panel/lib/panel-layout";
 
 const EMPTY_RESTORED_URLS: Partial<Record<ProviderId, string>> = {};
+const WORKSPACE_FRAMING_PROVIDERS = new Set<ProviderId>(["zai", "mimo"]);
 
 interface UseProviderFramesControllerOptions {
   frameRefs: MutableRefObject<Record<string, HTMLIFrameElement | null>>;
@@ -21,6 +22,7 @@ interface UseProviderFramesControllerOptions {
   // panel's first iframe src instead of the provider home page.
   restoredUrlByProvider?: Partial<Record<ProviderId, string>>;
   resumeEnabled?: boolean;
+  workspaceFramingReady?: boolean;
 }
 
 export function useProviderFramesController({
@@ -34,6 +36,7 @@ export function useProviderFramesController({
   temporaryChatEnabled,
   restoredUrlByProvider = EMPTY_RESTORED_URLS,
   resumeEnabled = false,
+  workspaceFramingReady = true,
 }: UseProviderFramesControllerOptions) {
   const [loadingProviders, setLoadingProviders] = useState<Record<string, boolean>>({});
   const [refreshByProvider, setRefreshByProvider] = useState<Record<string, number>>({});
@@ -179,7 +182,11 @@ export function useProviderFramesController({
   ) {
     frameHostRefs.current[providerId] = element;
 
-    if (!element || !isHydrated) {
+    if (
+      !element ||
+      !isHydrated ||
+      (!workspaceFramingReady && WORKSPACE_FRAMING_PROVIDERS.has(providerId))
+    ) {
       // Pre-hydration hosts are attached by the post-hydration effect below, so
       // the restore decision always runs once settings are loaded.
       return;
@@ -295,6 +302,13 @@ export function useProviderFramesController({
     const activeProviders = new Set(activePanelProviders);
 
     activePanelProviders.forEach((providerId) => {
+      if (
+        !workspaceFramingReady &&
+        WORKSPACE_FRAMING_PROVIDERS.has(providerId)
+      ) {
+        return;
+      }
+
       const provider = getProviderById(providerId);
       if (!provider) {
         return;
@@ -321,6 +335,7 @@ export function useProviderFramesController({
     refreshByProvider,
     resolvedTheme,
     temporaryChatEnabled,
+    workspaceFramingReady,
   ]);
 
   return {

--- a/src/multi-panel/hooks/useWorkspaceFramingReady.ts
+++ b/src/multi-panel/hooks/useWorkspaceFramingReady.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+
+const MAX_PREPARE_ATTEMPTS = 5;
+const PREPARE_RETRY_DELAY_MS = 200;
+
+export function useWorkspaceFramingReady() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let retryTimer: number | undefined;
+    let attempts = 0;
+
+    const prepare = async () => {
+      attempts += 1;
+
+      try {
+        const response = await chrome.runtime.sendMessage({
+          type: "PREPARE_WORKSPACE_FRAMING",
+        });
+        if (response?.ok === true) {
+          if (!cancelled) {
+            setReady(true);
+          }
+          return;
+        }
+      } catch {
+        // Retry below while the service worker starts or reloads.
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      if (attempts < MAX_PREPARE_ATTEMPTS) {
+        retryTimer = window.setTimeout(prepare, PREPARE_RETRY_DELAY_MS);
+        return;
+      }
+
+      // The service worker never confirmed the session rule. Fall back to the
+      // pre-handshake behavior so Z.ai and MiMo panels still render instead of
+      // staying blank; the tab-event prewarm usually covers this case anyway.
+      console.warn("[Parallel AI] Workspace framing setup was not confirmed; rendering panels anyway.");
+      setReady(true);
+    };
+
+    void prepare();
+
+    return () => {
+      cancelled = true;
+      if (retryTimer !== undefined) {
+        window.clearTimeout(retryTimer);
+      }
+    };
+  }, []);
+
+  return ready;
+}

--- a/src/multi-panel/lib/workspace-state.ts
+++ b/src/multi-panel/lib/workspace-state.ts
@@ -26,6 +26,7 @@ const PROVIDER_HOSTS: Record<ProviderId, readonly string[]> = {
   deepseek: ["chat.deepseek.com"],
   kimi: ["kimi.com", "www.kimi.com"],
   qwen: ["chat.qwen.ai"],
+  zai: ["chat.z.ai"],
   mimo: ["aistudio.xiaomimimo.com"],
   meta: ["meta.ai", "www.meta.ai"],
   google: ["google.com", "www.google.com"],

--- a/src/multi-panel/whats-new/changelog.ts
+++ b/src/multi-panel/whats-new/changelog.ts
@@ -18,10 +18,16 @@ export interface ChangelogEntry {
 // Monotonic counter bumped whenever a release adds a user-facing entry below.
 // Kept separate from the semantic version so silent patch releases don't trip
 // the toast; it is the value compared against the user's last-seen marker.
-export const CHANGELOG_VERSION = 4;
+export const CHANGELOG_VERSION = 5;
 
 // Newest first.
 export const CHANGELOG: ChangelogEntry[] = [
+  {
+    version: "1.0.7",
+    highlights: [
+      "Z.ai (GLM) and Xiaomi (MiMo) are available as new providers. Both are off by default; turn them on from the Settings tab.",
+    ],
+  },
   {
     version: "1.0.6",
     highlights: [

--- a/src/shared/lib/providers.ts
+++ b/src/shared/lib/providers.ts
@@ -6,6 +6,7 @@ export type ProviderId =
   | "deepseek"
   | "kimi"
   | "qwen"
+  | "zai"
   | "mimo"
   | "meta"
   | "google";
@@ -77,6 +78,14 @@ export const PROVIDERS = [
     enabled: true,
   },
   {
+    id: "zai",
+    name: "Z.ai",
+    url: "https://chat.z.ai/",
+    icon: "icons/providers/zai.svg",
+    iconDark: "icons/providers/dark/zai.svg",
+    enabled: true,
+  },
+  {
     id: "mimo",
     name: "Xiaomi MiMo",
     url: "https://aistudio.xiaomimimo.com/",
@@ -126,6 +135,7 @@ export const PROVIDER_COLORS = {
   deepseek: { light: "#4D6BFE", dark: "#6D85FF" }, // DeepSeek blue
   kimi: { light: "#6E5BFF", dark: "#8E7CFF" }, // Moonshot indigo
   qwen: { light: "#615CED", dark: "#8481FF" }, // Alibaba Qwen purple
+  zai: { light: "#1F63EC", dark: "#5B8FF5" }, // Z.ai blue
   mimo: { light: "#FF6900", dark: "#FF8533" }, // Xiaomi orange
   meta: { light: "#0866FF", dark: "#4C8DFF" }, // Meta blue
   google: { light: "#4285F4", dark: "#6BA1FF" }, // Google blue

--- a/tests/content-scripts/enter-behavior-zai.test.ts
+++ b/tests/content-scripts/enter-behavior-zai.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { seedFocusedTextarea, setupProvider } from "./helpers/enter-setup";
+import { dispatchTrustedKeydown, resetEnterBehaviorGlobals } from "./helpers/load-script";
+
+describe("enter-behavior-zai", () => {
+  afterEach(() => {
+    resetEnterBehaviorGlobals();
+  });
+
+  it("inserts a newline into the chat input on Shift+Enter", async () => {
+    await setupProvider(["enter-behavior-utils.js", "enter-behavior-zai.js"], "default");
+    const textarea = seedFocusedTextarea("abc");
+    textarea.id = "chat-input";
+
+    dispatchTrustedKeydown(window, { shiftKey: true });
+
+    expect(textarea.value).toBe("abc\n");
+  });
+
+  it("clicks the Z.ai send button on plain Enter", async () => {
+    await setupProvider(["enter-behavior-utils.js", "enter-behavior-zai.js"], "default");
+    const textarea = seedFocusedTextarea("hello");
+    textarea.id = "chat-input";
+    const button = document.createElement("button");
+    button.id = "send-message-button";
+    document.body.appendChild(button);
+    const clicks = vi.fn();
+    button.addEventListener("click", clicks);
+
+    dispatchTrustedKeydown(window);
+
+    expect(clicks).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends on Shift+Enter when the preset is swapped", async () => {
+    await setupProvider(["enter-behavior-utils.js", "enter-behavior-zai.js"], "swapped");
+    const textarea = seedFocusedTextarea("hello");
+    textarea.id = "chat-input";
+    const button = document.createElement("button");
+    button.id = "send-message-button";
+    document.body.appendChild(button);
+    const clicks = vi.fn();
+    button.addEventListener("click", clicks);
+
+    dispatchTrustedKeydown(window, { shiftKey: true });
+
+    expect(clicks).toHaveBeenCalledTimes(1);
+    expect(textarea.value).toBe("hello");
+  });
+});

--- a/tests/content-scripts/new-chat-selectors.test.ts
+++ b/tests/content-scripts/new-chat-selectors.test.ts
@@ -130,6 +130,15 @@ describe("new chat button selectors", () => {
     expect(NEW_CHAT_URLS.mimo).toBe("https://aistudio.xiaomimimo.com/");
   });
 
+  it("uses Z.ai's explicit desktop new-chat control and canonical root", () => {
+    const newChat = document.createElement("button");
+    newChat.id = "sidebar-new-chat-button";
+    document.body.appendChild(newChat);
+
+    expect(findFirstSelectorMatch(SELECTORS.zai)).toBe(newChat);
+    expect(NEW_CHAT_URLS.zai).toBe("https://chat.z.ai/");
+  });
+
   it("prefers the real new-chat link over a news link in document order", () => {
     // News banner appears before the sidebar new-chat link in the DOM.
     makeLink(NEWS_LINK);

--- a/tests/content-scripts/zai-image-submit.test.ts
+++ b/tests/content-scripts/zai-image-submit.test.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type AutoSubmitOptions = {
+  delay?: number;
+  retryUntilReady?: boolean;
+  timeout?: number;
+  waitUntil?: () => boolean;
+};
+
+type AutoSubmitScheduler = (
+  provider: string,
+  providerMode?: string | null,
+  options?: AutoSubmitOptions,
+) => void;
+
+const source = readFileSync(
+  path.resolve(process.cwd(), "content-scripts", "text-injection-all-providers.js"),
+  "utf8",
+);
+
+function extractNamedFunction(name: string): string {
+  const match = source.match(
+    new RegExp(
+      `\\n([ \\t]*)function ${name}\\([^)]*\\) \\{[\\s\\S]*?\\n\\1\\}`,
+    ),
+  );
+  if (!match) {
+    throw new Error(`${name} not found in content script`);
+  }
+  return match[0];
+}
+
+function loadAutoSubmitScheduler(clickSendButton: () => boolean): AutoSubmitScheduler {
+  return new Function(
+    "getProviderAutoSubmitDelay",
+    "clickSendButton",
+    "CHATGPT_AUTO_SUBMIT_TIMEOUT_MS",
+    "CHATGPT_AUTO_SUBMIT_POLL_INTERVAL_MS",
+    `${extractNamedFunction("scheduleProviderAutoSubmit")}; return scheduleProviderAutoSubmit;`,
+  )(
+    () => 500,
+    clickSendButton,
+    2500,
+    150,
+  ) as AutoSubmitScheduler;
+}
+
+function loadZaiImageAttachmentReady(): () => boolean {
+  return new Function(
+    `${extractNamedFunction("isZaiImageAttachmentReady")}; return isZaiImageAttachmentReady;`,
+  )() as () => boolean;
+}
+
+function mountZaiComposer(chipInnerHtml: string) {
+  document.body.innerHTML = `
+    <form>
+      <button type="button" class="relative group flex items-center gap-2.5 max-w-[280px] w-60 shrink-0">
+        ${chipInnerHtml}
+      </button>
+      <textarea id="chat-input"></textarea>
+      <button id="send-message-button" type="submit"></button>
+    </form>
+  `;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("Z.ai image auto-submit", () => {
+  it("retries until the send control becomes ready", async () => {
+    vi.useFakeTimers();
+    const clickSendButton = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+    const schedule = loadAutoSubmitScheduler(clickSendButton);
+
+    schedule("zai", null, {
+      delay: 0,
+      retryUntilReady: true,
+      timeout: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(clickSendButton).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(clickSendButton).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(clickSendButton).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(clickSendButton).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not click send while waitUntil reports the attachment is still uploading", async () => {
+    vi.useFakeTimers();
+    const clickSendButton = vi.fn<() => boolean>().mockReturnValue(true);
+    const waitUntil = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+    const schedule = loadAutoSubmitScheduler(clickSendButton);
+
+    schedule("zai", null, {
+      delay: 0,
+      retryUntilReady: true,
+      timeout: 1000,
+      waitUntil,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(clickSendButton).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(clickSendButton).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(150);
+    expect(clickSendButton).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a spinner chip as not ready and an image preview as ready", () => {
+    const isReady = loadZaiImageAttachmentReady();
+
+    mountZaiComposer(`
+      <div class="shrink-0 flex items-center justify-center w-8 h-10">
+        <svg class="size-4 text-text-secondary"></svg>
+      </div>
+    `);
+    expect(isReady()).toBe(false);
+
+    mountZaiComposer(`
+      <div class="shrink-0 flex items-center justify-center w-8 h-10">
+        <img alt="photo.png" class="object-cover">
+      </div>
+    `);
+    expect(isReady()).toBe(true);
+  });
+
+  it("is not ready before any upload chip exists", () => {
+    document.body.innerHTML = `
+      <form>
+        <textarea id="chat-input"></textarea>
+        <button id="send-message-button" type="submit"></button>
+      </form>
+    `;
+
+    expect(loadZaiImageAttachmentReady()()).toBe(false);
+  });
+});

--- a/tests/content-scripts/zai-selectors.test.ts
+++ b/tests/content-scripts/zai-selectors.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  path.resolve(process.cwd(), "content-scripts", "text-injection-all-providers.js"),
+  "utf8",
+);
+
+function loadSelectorTable(name: string): Record<string, string[]> {
+  const match = source.match(
+    new RegExp(`\\n([ \\t]*)const ${name} = (\\{[\\s\\S]*?\\n\\1\\});`),
+  );
+  if (!match) {
+    throw new Error(`${name} not found in content script`);
+  }
+  return new Function(`return ${match[2]}`)() as Record<string, string[]>;
+}
+
+const INPUT_SELECTORS = loadSelectorTable("PROVIDER_SELECTORS");
+const SEND_SELECTORS = loadSelectorTable("SEND_BUTTON_SELECTORS");
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("Z.ai selectors", () => {
+  it("matches the live chat editor", () => {
+    const editor = document.createElement("textarea");
+    editor.id = "chat-input";
+    editor.placeholder = "How can I help you today?";
+    document.body.appendChild(editor);
+
+    expect(editor.matches(INPUT_SELECTORS.zai.join(", "))).toBe(true);
+  });
+
+  it("matches the live send control without a broad page-wide button fallback", () => {
+    const send = document.createElement("button");
+    send.id = "send-message-button";
+    send.type = "submit";
+    document.body.appendChild(send);
+
+    expect(send.matches(SEND_SELECTORS.zai.join(", "))).toBe(true);
+    expect(SEND_SELECTORS.zai).not.toContain("button");
+  });
+});

--- a/tests/hooks/useProviderFramesController.test.ts
+++ b/tests/hooks/useProviderFramesController.test.ts
@@ -13,6 +13,7 @@ interface HarnessOverrides {
   resolvedTheme?: "light" | "dark";
   restoredUrlByProvider?: Partial<Record<ProviderId, string>>;
   resumeEnabled?: boolean;
+  workspaceFramingReady?: boolean;
 }
 
 function makeHarness(overrides: HarnessOverrides = {}) {
@@ -21,12 +22,13 @@ function makeHarness(overrides: HarnessOverrides = {}) {
   const onProviderFrameLoad = vi.fn();
 
   const utils = renderHookWithProviders(
-    ({ providers, mode, hydrated, tempChat, theme }: {
+    ({ providers, mode, hydrated, tempChat, theme, framingReady }: {
       providers: (ProviderId | null)[];
       mode: "ai" | "search";
       hydrated: boolean;
       tempChat: boolean;
       theme: "light" | "dark";
+      framingReady?: boolean;
     }) =>
       useProviderFramesController({
         frameRefs: frameRefs as never,
@@ -39,6 +41,7 @@ function makeHarness(overrides: HarnessOverrides = {}) {
         temporaryChatEnabled: tempChat,
         restoredUrlByProvider: overrides.restoredUrlByProvider,
         resumeEnabled: overrides.resumeEnabled,
+        workspaceFramingReady: framingReady ?? true,
       }),
     {
       initialProps: {
@@ -47,6 +50,7 @@ function makeHarness(overrides: HarnessOverrides = {}) {
         hydrated: overrides.isHydrated ?? true,
         tempChat: overrides.temporaryChatEnabled ?? false,
         theme: overrides.resolvedTheme ?? "light",
+        framingReady: overrides.workspaceFramingReady ?? true,
       },
     },
   );
@@ -77,6 +81,37 @@ describe("useProviderFramesController", () => {
     expect(h.frameRefs.current.chatgpt).toBeInstanceOf(HTMLIFrameElement);
     expect(host.firstChild).toBe(h.frameRefs.current.chatgpt);
     expect(h.queueConnectorLayoutRefresh).toHaveBeenCalled();
+  });
+
+  it("waits for framing readiness before creating a Z.ai iframe", async () => {
+    const providers = ["zai"] as ProviderId[];
+    const h = makeHarness({
+      panelProviders: providers,
+      workspaceFramingReady: false,
+    });
+    const host = document.createElement("div");
+
+    act(() => {
+      h.result.current.registerFrameHost(
+        "zai" as ProviderId,
+        "https://chat.z.ai/",
+        "Z.ai",
+        host,
+      );
+    });
+    expect(h.frameRefs.current.zai).toBeUndefined();
+
+    h.rerender({
+      providers,
+      mode: "ai",
+      hydrated: true,
+      tempChat: false,
+      theme: "light",
+      framingReady: true,
+    });
+
+    expect(h.frameRefs.current.zai).toBeInstanceOf(HTMLIFrameElement);
+    expect(h.frameRefs.current.zai?.src).toBe("https://chat.z.ai/");
   });
 
   it("marks the provider as loading on first src assignment", () => {

--- a/tests/hooks/useWorkspaceFramingReady.test.ts
+++ b/tests/hooks/useWorkspaceFramingReady.test.ts
@@ -1,0 +1,79 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWorkspaceFramingReady } from "@/multi-panel/hooks/useWorkspaceFramingReady";
+
+describe("useWorkspaceFramingReady", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stays false until the service worker confirms the session rule", async () => {
+    let resolveMessage: ((value: { ok: boolean }) => void) | undefined;
+    chrome.runtime.sendMessage = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveMessage = resolve;
+        }),
+    ) as never;
+
+    const { result } = renderHook(() => useWorkspaceFramingReady());
+    expect(result.current).toBe(false);
+
+    await act(async () => {
+      resolveMessage?.({ ok: true });
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("retries a transient framing setup failure", async () => {
+    chrome.runtime.sendMessage = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true }) as never;
+
+    const { result } = renderHook(() => useWorkspaceFramingReady());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(result.current).toBe(true);
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to rendering panels after the retry budget is exhausted", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    chrome.runtime.sendMessage = vi.fn().mockResolvedValue({ ok: false }) as never;
+
+    const { result } = renderHook(() => useWorkspaceFramingReady());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200 * 3);
+    });
+    expect(result.current).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(result.current).toBe(true);
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledTimes(5);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+});

--- a/tests/setup/chrome-mock.ts
+++ b/tests/setup/chrome-mock.ts
@@ -202,6 +202,7 @@ export function installChromeMock(): void {
       move: vi.fn(() => Promise.resolve(undefined)),
       remove: vi.fn(() => Promise.resolve()),
       sendMessage: vi.fn(() => Promise.resolve({ ok: true })),
+      onCreated: { addListener: vi.fn(), removeListener: vi.fn(), hasListener: vi.fn() },
       onUpdated: { addListener: vi.fn(), removeListener: vi.fn(), hasListener: vi.fn() },
       onActivated: { addListener: vi.fn(), removeListener: vi.fn(), hasListener: vi.fn() },
       onRemoved: { addListener: vi.fn(), removeListener: vi.fn(), hasListener: vi.fn() },

--- a/tests/unit/manifest-guardrails.test.ts
+++ b/tests/unit/manifest-guardrails.test.ts
@@ -162,6 +162,14 @@ describe("manifest guardrails", () => {
     expect(accountRules).toEqual([]);
   });
 
+  it("does not expose Z.ai framing through browser-wide static rules", () => {
+    const zaiRules = bypassRules.filter(({ condition }) =>
+      condition.urlFilter.includes("chat.z.ai"),
+    );
+
+    expect(zaiRules).toEqual([]);
+  });
+
   it("requires Chrome 130 for complete partition-key fallback support", () => {
     expect(Number(manifest.minimum_chrome_version)).toBeGreaterThanOrEqual(130);
   });

--- a/tests/unit/providers.test.ts
+++ b/tests/unit/providers.test.ts
@@ -14,7 +14,7 @@ describe("providers", () => {
   });
 
   it("contains the expected providers", () => {
-    expect(PROVIDERS).toHaveLength(10);
+    expect(PROVIDERS).toHaveLength(11);
     expect(PROVIDERS.map((provider) => provider.id)).toEqual([
       "chatgpt",
       "claude",
@@ -23,6 +23,7 @@ describe("providers", () => {
       "deepseek",
       "kimi",
       "qwen",
+      "zai",
       "mimo",
       "meta",
       "google",
@@ -31,6 +32,7 @@ describe("providers", () => {
 
   it("returns providers by id", () => {
     expect(getProviderById("chatgpt")?.name).toBe("ChatGPT");
+    expect(getProviderById("zai")?.url).toBe("https://chat.z.ai/");
     expect(getProviderById("google")?.iconDark).toContain("dark/google");
   });
 

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -21,9 +21,14 @@ interface ChromeListeners {
   onStartup: Array<(...args: unknown[]) => unknown>;
   actionClicked: Array<(...args: unknown[]) => unknown>;
   contextMenuClicked: Array<(info: chrome.contextMenus.OnClickData) => unknown>;
+  tabCreated: Array<(tab: chrome.tabs.Tab) => unknown>;
   tabRemoved: Array<(tabId: number) => unknown>;
   tabUpdated: Array<
-    (tabId: number, changeInfo: chrome.tabs.TabChangeInfo) => unknown
+    (
+      tabId: number,
+      changeInfo: chrome.tabs.TabChangeInfo,
+      tab?: chrome.tabs.Tab,
+    ) => unknown
   >;
 }
 
@@ -31,6 +36,12 @@ const MIMO_SENDER = {
   tab: { id: 42, url: "chrome-extension://test/multi-panel/index.html" },
   frameId: 3,
   url: "https://aistudio.xiaomimimo.com/#/c",
+} as chrome.runtime.MessageSender;
+
+const WORKSPACE_SENDER = {
+  tab: { id: 7, url: "chrome-extension://test/multi-panel/index.html" },
+  frameId: 0,
+  url: "chrome-extension://test/multi-panel/index.html",
 } as chrome.runtime.MessageSender;
 
 const PRE_MIMO_ENABLED_PROVIDERS = [
@@ -53,6 +64,7 @@ const CURRENT_ENABLED_PROVIDERS = [
   "deepseek",
   "kimi",
   "qwen",
+  "zai",
   "mimo",
   "meta",
   "google",
@@ -64,6 +76,7 @@ function loadServiceWorker(): ChromeListeners {
     onStartup: [],
     actionClicked: [],
     contextMenuClicked: [],
+    tabCreated: [],
     tabRemoved: [],
     tabUpdated: [],
   };
@@ -80,6 +93,9 @@ function loadServiceWorker(): ChromeListeners {
   chrome.contextMenus.onClicked = {
     addListener: vi.fn((fn) => listeners.contextMenuClicked.push(fn as never)),
   } as unknown as typeof chrome.contextMenus.onClicked;
+  chrome.tabs.onCreated = {
+    addListener: vi.fn((fn) => listeners.tabCreated.push(fn as never)),
+  } as unknown as typeof chrome.tabs.onCreated;
   chrome.tabs.onRemoved = {
     addListener: vi.fn((fn) => listeners.tabRemoved.push(fn as never)),
   } as unknown as typeof chrome.tabs.onRemoved;
@@ -110,6 +126,8 @@ describe("background service worker", () => {
       },
     );
     chrome.tabs.create = vi.fn(() => Promise.resolve({ id: 1 }));
+    chrome.tabs.update = vi.fn(() => Promise.resolve(undefined));
+    chrome.tabs.query = vi.fn(() => Promise.resolve([]));
     chrome.contextMenus.removeAll = vi.fn(() => Promise.resolve());
     chrome.contextMenus.create = vi.fn((_opts, callback?: () => void) => {
       callback?.();
@@ -122,6 +140,7 @@ describe("background service worker", () => {
     expect(listeners.onStartup).toHaveLength(1);
     expect(listeners.actionClicked).toHaveLength(1);
     expect(listeners.contextMenuClicked).toHaveLength(1);
+    expect(listeners.tabCreated).toHaveLength(1);
     expect(listeners.tabRemoved).toHaveLength(1);
     expect(listeners.tabUpdated).toHaveLength(1);
   });
@@ -139,8 +158,14 @@ describe("background service worker", () => {
     await listeners.onInstalled[0]!({ reason: "install" });
     expect(chrome.tabs.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.stringContaining("multi-panel/index.html"),
+        url: "about:blank",
         active: true,
+      }),
+    );
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        url: expect.stringContaining("multi-panel/index.html"),
       }),
     );
   });
@@ -237,14 +262,21 @@ describe("background service worker", () => {
   it("onStartup also creates the context menu", async () => {
     await listeners.onStartup[0]!();
     expect(chrome.contextMenus.create).toHaveBeenCalled();
+    expect(chrome.tabs.query).toHaveBeenCalledWith({});
   });
 
   it("action onClicked opens the multi-panel tab", async () => {
     await listeners.actionClicked[0]!();
     expect(chrome.tabs.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: expect.stringContaining("multi-panel/index.html"),
+        url: "about:blank",
         active: true,
+      }),
+    );
+    expect(chrome.tabs.update).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        url: expect.stringContaining("multi-panel/index.html"),
       }),
     );
     expect(sessionRules).toEqual([
@@ -252,7 +284,30 @@ describe("background service worker", () => {
         id: 17_001,
         condition: expect.objectContaining({ tabIds: [1] }),
       }),
+      expect.objectContaining({
+        id: 17_002,
+        condition: expect.objectContaining({
+          urlFilter: "|https://chat.z.ai/",
+          tabIds: [1],
+        }),
+      }),
     ]);
+  });
+
+  it("installs framing rules before navigating a new workspace tab", async () => {
+    const order: string[] = [];
+    chrome.declarativeNetRequest.updateSessionRules = vi.fn(async (update) => {
+      order.push("framing");
+      sessionRules.push(...(update.addRules ?? []));
+    });
+    chrome.tabs.update = vi.fn(async () => {
+      order.push("navigate");
+      return undefined;
+    }) as never;
+
+    await listeners.actionClicked[0]!();
+
+    expect(order).toEqual(["framing", "navigate"]);
   });
 
   it("context menu with selection stores pending sendToPanel + opens tab", async () => {
@@ -428,6 +483,21 @@ describe("background service worker", () => {
           tabIds: [42],
         },
       },
+      {
+        id: 17_002,
+        priority: 1,
+        action: {
+          type: "modifyHeaders",
+          responseHeaders: [
+            { header: "X-Frame-Options", operation: "remove" },
+          ],
+        },
+        condition: {
+          urlFilter: "|https://chat.z.ai/",
+          resourceTypes: ["sub_frame"],
+          tabIds: [42],
+        },
+      },
     ]);
     expect(responses).toContainEqual({
       supported: true,
@@ -591,9 +661,10 @@ describe("background service worker", () => {
     });
   });
 
-  it("removes MiMo framing access when its workspace tab closes", async () => {
+  it("removes workspace-scoped framing access when its tab closes", async () => {
     await listeners.actionClicked[0]!();
-    expect(sessionRules[0]?.condition.tabIds).toEqual([1]);
+    expect(sessionRules).toHaveLength(2);
+    expect(sessionRules.every((rule) => rule.condition.tabIds?.[0] === 1)).toBe(true);
 
     listeners.tabRemoved[0]!(1);
     await flushAsync();
@@ -601,14 +672,112 @@ describe("background service worker", () => {
     expect(sessionRules).toEqual([]);
   });
 
-  it("removes MiMo framing access when its workspace tab navigates away", async () => {
+  it("removes workspace-scoped framing access when its tab navigates away", async () => {
     await listeners.actionClicked[0]!();
-    expect(sessionRules[0]?.condition.tabIds).toEqual([1]);
+    expect(sessionRules).toHaveLength(2);
+    expect(sessionRules.every((rule) => rule.condition.tabIds?.[0] === 1)).toBe(true);
 
     listeners.tabUpdated[0]!(1, { url: "https://example.com/" });
     await flushAsync();
 
     expect(sessionRules).toEqual([]);
+  });
+
+  it("restores workspace-scoped framing rules for open workspace tabs on startup", async () => {
+    chrome.tabs.query = vi.fn(() =>
+      Promise.resolve([
+        { id: 7, url: "chrome-extension://test/multi-panel/index.html?s=abc" },
+        { id: 8, url: "https://example.com/" },
+      ]),
+    ) as never;
+
+    await listeners.onStartup[0]!();
+
+    expect(sessionRules).toHaveLength(2);
+    expect(sessionRules.every((rule) => rule.condition.tabIds?.[0] === 7)).toBe(true);
+  });
+
+  it("confirms framing readiness before the workspace creates iframes", async () => {
+    const responses = emitRuntimeMessage(
+      { type: "PREPARE_WORKSPACE_FRAMING" },
+      WORKSPACE_SENDER,
+    );
+    await flushAsync();
+
+    expect(responses).toContainEqual({ ok: true });
+    expect(sessionRules).toEqual([
+      expect.objectContaining({
+        id: 17_001,
+        condition: expect.objectContaining({ tabIds: [7] }),
+      }),
+      expect.objectContaining({
+        id: 17_002,
+        condition: expect.objectContaining({
+          urlFilter: "|https://chat.z.ai/",
+          tabIds: [7],
+        }),
+      }),
+    ]);
+  });
+
+  it("rejects framing readiness requests outside the workspace top frame", async () => {
+    const responses = emitRuntimeMessage(
+      { type: "PREPARE_WORKSPACE_FRAMING" },
+      {
+        ...WORKSPACE_SENDER,
+        frameId: 2,
+        url: "https://chat.z.ai/",
+      },
+    );
+    await flushAsync();
+
+    expect(responses).toContainEqual({ ok: false });
+    expect(sessionRules).toEqual([]);
+  });
+
+  it("installs workspace framing rules before creating context menus on startup", async () => {
+    const order: string[] = [];
+    chrome.tabs.query = vi.fn(async () => {
+      order.push("framing");
+      return [
+        { id: 7, url: "chrome-extension://test/multi-panel/index.html?s=abc" },
+      ];
+    }) as never;
+    chrome.contextMenus.removeAll = vi.fn(async () => {
+      order.push("menus");
+    }) as never;
+
+    await listeners.onStartup[0]!();
+
+    expect(order[0]).toBe("framing");
+    expect(order.indexOf("framing")).toBeLessThan(order.indexOf("menus"));
+    expect(sessionRules.every((rule) => rule.condition.tabIds?.[0] === 7)).toBe(true);
+  });
+
+  it("enables workspace framing when a workspace tab is created", async () => {
+    listeners.tabCreated[0]!({
+      id: 9,
+      pendingUrl: "chrome-extension://test/multi-panel/index.html",
+    } as chrome.tabs.Tab);
+    await flushAsync();
+
+    expect(sessionRules).toHaveLength(2);
+    expect(sessionRules.every((rule) => rule.condition.tabIds?.[0] === 9)).toBe(true);
+  });
+
+  it("enables workspace framing when a restored tab starts loading without a url change", async () => {
+    listeners.tabUpdated[0]!(
+      7,
+      { status: "loading" },
+      {
+        id: 7,
+        url: "chrome-extension://test/multi-panel/index.html?s=abc",
+      } as chrome.tabs.Tab,
+    );
+    await flushAsync();
+
+    expect(sessionRules).toHaveLength(2);
+    expect(sessionRules.every((rule) => rule.condition.tabIds?.[0] === 7)).toBe(true);
   });
 
   it("does not rewrite MiMo's POST auth cookie when the partition is current", async () => {

--- a/tests/unit/workspace-state.test.ts
+++ b/tests/unit/workspace-state.test.ts
@@ -24,6 +24,17 @@ describe("workspace-state", () => {
     expect(decodeWorkspaceState(encodeWorkspaceState(baseState))).toEqual(baseState);
   });
 
+  it("round-trips a Z.ai workspace and conversation URL", () => {
+    const zaiState: WorkspaceState = {
+      v: WORKSPACE_STATE_VERSION,
+      layout: "1x1",
+      panels: ["zai"],
+      urls: { zai: "https://chat.z.ai/c/abc" },
+    };
+
+    expect(decodeWorkspaceState(encodeWorkspaceState(zaiState))).toEqual(zaiState);
+  });
+
   it("returns null for empty or malformed params", () => {
     expect(decodeWorkspaceState(null)).toBeNull();
     expect(decodeWorkspaceState("")).toBeNull();
@@ -89,6 +100,7 @@ describe("workspace-state", () => {
       expect(isRestorableProviderUrl("chatgpt", "https://chatgpt.com/c/abc")).toBe(true);
       expect(isRestorableProviderUrl("chatgpt", "https://chat.openai.com/c/abc")).toBe(true);
       expect(isRestorableProviderUrl("mimo", "https://aistudio.xiaomimimo.com/#/c")).toBe(true);
+      expect(isRestorableProviderUrl("zai", "https://chat.z.ai/c/abc")).toBe(true);
     });
 
     it("rejects wrong-host, non-https, Google, and non-URL values", () => {
@@ -97,6 +109,7 @@ describe("workspace-state", () => {
       expect(isRestorableProviderUrl("google", "https://www.google.com/")).toBe(false);
       expect(isRestorableProviderUrl("chatgpt", "javascript:alert(1)")).toBe(false);
       expect(isRestorableProviderUrl("chatgpt", 42)).toBe(false);
+      expect(isRestorableProviderUrl("zai", "https://evil.example.com/c/abc")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds Z.ai (chat.z.ai) as a provider panel, bumping the extension to 1.0.7.

- Register the Z.ai provider: types, registry entry, colors, light/dark icons, workspace host mapping, manifest host permission, and a dedicated content script bundle (`src/content/zai.ts`).
- Frame Z.ai inside the workspace with a per-tab session `declarativeNetRequest` rule (id 17_002) that removes only `X-Frame-Options` for `chat.z.ai` sub-frames in open workspace tabs, generalizing the existing MiMo session rule plumbing. Z.ai serves no CSP `frame-ancestors`, so removing XFO is sufficient.
- Close the load-order race between iframe creation and rule installation: the workspace page sends a `PREPARE_WORKSPACE_FRAMING` handshake and the `useWorkspaceFramingReady` hook gates Z.ai/MiMo iframe creation until the service worker confirms the rule. Tab-created and restore-loading events prewarm the rule, and `openMultiPanel` installs it before navigating the new tab. If confirmation never arrives, the hook falls back to rendering after ~1s so panels cannot hang blank.
- Provider selectors for input, send, stop, and new-chat controls, plus an Enter/Shift+Enter behavior swap matching the other providers.
- Image auto-submit waits for the upload chip's preview image (`isZaiImageAttachmentReady`), since Z.ai keeps the send button enabled while uploads are still in flight.
- Docs: README permission table and architecture diagram, PRIVACY policy list, Chrome/Edge store submission notes, and a 1.0.7 changelog entry.

## Testing

- `bun run test`: 100 files, 830 tests pass, including new suites for Z.ai selectors, enter behavior, image auto-submit readiness, framing handshake, and service-worker rule ordering.
- `tsc --noEmit`: clean.
- `bun run build`: builds and passes the shippable check.