### PR TITLE
chore(dev): restore workspace tabs after extension reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,10 @@ The output lands in `dist/`.
 3. Click **Load unpacked** and select the `dist/` folder.
 4. Pin the **Parallel AI** action and click it (or press `Ctrl/Cmd+Shift+E`) to open the workspace.
 
+Unpacked installs automatically reopen their open workspaces after you click
+**Reload** on `chrome://extensions`. This uses the saved workspace URLs; unsent
+text and temporary chats are not restored. Web Store installs skip this developer convenience.
+
 ### Tests
 
 ```bash

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -46,6 +46,52 @@ const CURRENT_ENABLED_PROVIDERS = [
 
 let workspaceFramingRuleUpdate = Promise.resolve();
 
+// Developer convenience: Chrome closes extension pages when an unpacked
+// extension is reloaded. Their URLs already contain the workspace state.
+// getSelf() needs no extra permission; Web Store installs never use this path.
+const DEV_WORKSPACES_KEY = "devOpenWorkspaces";
+const isDevelopmentInstall = chrome.management?.getSelf()
+  .then((self) => self.installType === "development")
+  .catch(() => false) ?? Promise.resolve(false);
+let devWorkspaceUpdate = Promise.resolve();
+
+function queueDevWorkspaceUpdate(update) {
+  // Serialize tab events with restoration so newly opened tabs cannot replace
+  // the saved list while we are still reading/reopening it.
+  devWorkspaceUpdate = devWorkspaceUpdate.then(async () => {
+    if (!(await isDevelopmentInstall)) return;
+    const saved = (await chrome.storage.local.get(DEV_WORKSPACES_KEY))[DEV_WORKSPACES_KEY];
+    const workspaces = (Array.isArray(saved) ? saved : [])
+      .filter((tab) => Number.isInteger(tab?.id) && isMultiPanelTabUrl(tab?.url));
+    await chrome.storage.local.set({ [DEV_WORKSPACES_KEY]: await update(workspaces) });
+  }).catch((error) => console.warn("Could not preserve development workspaces", error));
+  return devWorkspaceUpdate;
+}
+
+function rememberDevWorkspace(tabId, url) {
+  return queueDevWorkspaceUpdate((saved) => {
+    const next = saved.filter((tab) => tab.id !== tabId);
+    if (isMultiPanelTabUrl(url)) next.push({ id: tabId, url });
+    return next;
+  });
+}
+
+function restoreDevWorkspaces() {
+  return queueDevWorkspaceUpdate(async (saved) => {
+    const openIds = new Set((await chrome.tabs.query({})).map((tab) => tab.id));
+    const restored = [];
+    for (const tab of saved) {
+      if (openIds.has(tab.id)) {
+        restored.push(tab);
+      } else {
+        const opened = await chrome.tabs.create({ url: tab.url, active: false });
+        restored.push({ id: opened.id, url: tab.url });
+      }
+    }
+    return restored;
+  });
+}
+
 function isMultiPanelTabUrl(value) {
   if (typeof value !== "string") return false;
 
@@ -438,6 +484,19 @@ async function publishClaudeWorkspace() {
 }
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (
+    sender.frameId === 0 &&
+    typeof sender.tab?.id === "number" &&
+    isMultiPanelTabUrl(sender.url)
+  ) {
+    if (message?.type === "DEV_WORKSPACE_URL" && isMultiPanelTabUrl(message.url)) {
+      rememberDevWorkspace(sender.tab.id, message.url).then(() => sendResponse({ ok: true }));
+      return true;
+    }
+    if (message?.type === "PREPARE_WORKSPACE_FRAMING") {
+      void rememberDevWorkspace(sender.tab.id, sender.url);
+    }
+  }
   if (message?.type === "PREPARE_WORKSPACE_FRAMING") {
     prepareWorkspaceFraming(sender).then(sendResponse);
     return true;
@@ -463,6 +522,7 @@ chrome.cookies?.onChanged?.addListener((change) => {
 });
 
 chrome.tabs?.onRemoved?.addListener((tabId) => {
+  void rememberDevWorkspace(tabId, null);
   void disableWorkspaceFramingForTab(tabId);
 });
 
@@ -582,6 +642,9 @@ function getSelectedTextFromContext(info) {
 }
 
 chrome.runtime.onInstalled.addListener(async (details) => {
+  // An unpacked reload fires onInstalled with reason "update". Restore before
+  // any startup work can overwrite the snapshot; worker wakeups never restore.
+  if (details?.reason === "update") await restoreDevWorkspaces();
   await syncWorkspaceFramingRulesWithOpenTabs();
   await createContextMenus();
   void publishClaudeWorkspace();
@@ -601,6 +664,7 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 });
 
 chrome.runtime.onStartup.addListener(async () => {
+  await queueDevWorkspaceUpdate(() => []);
   await syncWorkspaceFramingRulesWithOpenTabs();
   await createContextMenus();
   void publishClaudeWorkspace();

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -50,9 +50,9 @@ let workspaceFramingRuleUpdate = Promise.resolve();
 // extension is reloaded. Their URLs already contain the workspace state.
 // getSelf() needs no extra permission; Web Store installs never use this path.
 const DEV_WORKSPACES_KEY = "devOpenWorkspaces";
-const isDevelopmentInstall = chrome.management?.getSelf()
-  .then((self) => self.installType === "development")
-  .catch(() => false) ?? Promise.resolve(false);
+const isDevelopmentInstall = Promise.resolve(chrome.management?.getSelf?.())
+  .then((self) => self?.installType === "development")
+  .catch(() => false);
 let devWorkspaceUpdate = Promise.resolve();
 
 function queueDevWorkspaceUpdate(update) {
@@ -84,8 +84,15 @@ function restoreDevWorkspaces() {
       if (openIds.has(tab.id)) {
         restored.push(tab);
       } else {
-        const opened = await chrome.tabs.create({ url: tab.url, active: false });
-        restored.push({ id: opened.id, url: tab.url });
+        try {
+          const opened = await chrome.tabs.create({ url: tab.url, active: false });
+          restored.push({ id: opened.id, url: tab.url });
+        } catch (error) {
+          // Keep the stale record so a later reload retries only this tab. Any
+          // earlier successful replacements are still persisted below.
+          console.warn("Could not restore development workspace", error);
+          restored.push(tab);
+        }
       }
     }
     return restored;

--- a/src/multi-panel/hooks/useWorkspaceUrlController.ts
+++ b/src/multi-panel/hooks/useWorkspaceUrlController.ts
@@ -13,6 +13,9 @@ import {
 } from "@/multi-panel/lib/workspace-state";
 
 const PERSIST_DEBOUNCE_MS = 600;
+const isDevelopmentInstall = chrome.management?.getSelf()
+  .then((self) => self.installType === "development")
+  .catch(() => false) ?? Promise.resolve(false);
 
 interface UseWorkspaceUrlControllerOptions {
   isHydrated: boolean;
@@ -89,4 +92,10 @@ function replaceWorkspaceUrl(state: WorkspaceState | null) {
   );
   // replaceState (not push) so the back button is untouched.
   window.history.replaceState(window.history.state, "", nextUrl);
+  // The worker cannot read extension-tab URLs without the broad tabs permission.
+  // Report this URL only from unpacked development installs.
+  void isDevelopmentInstall.then((isDevelopment) => {
+    if (!isDevelopment) return;
+    return chrome.runtime.sendMessage({ type: "DEV_WORKSPACE_URL", url: window.location.href });
+  }).catch(() => {});
 }

--- a/src/multi-panel/hooks/useWorkspaceUrlController.ts
+++ b/src/multi-panel/hooks/useWorkspaceUrlController.ts
@@ -13,9 +13,9 @@ import {
 } from "@/multi-panel/lib/workspace-state";
 
 const PERSIST_DEBOUNCE_MS = 600;
-const isDevelopmentInstall = chrome.management?.getSelf()
-  .then((self) => self.installType === "development")
-  .catch(() => false) ?? Promise.resolve(false);
+const isDevelopmentInstall = Promise.resolve(chrome.management?.getSelf?.())
+  .then((self) => self?.installType === "development")
+  .catch(() => false);
 
 interface UseWorkspaceUrlControllerOptions {
   isHydrated: boolean;

--- a/tests/e2e/fixtures/dev-reload.spec.ts
+++ b/tests/e2e/fixtures/dev-reload.spec.ts
@@ -1,0 +1,73 @@
+import { Buffer } from "node:buffer";
+
+import { expect, test } from "../_fixtures";
+
+test("unpacked reload restores open workspaces but not an intentionally closed tab", async ({ context, extensionId }) => {
+  // Apply to the context so tabs recreated by the service worker are stubbed too.
+  await context.route(/^https?:/, (route) => route.fulfill({
+    contentType: "text/html",
+    body: "<!doctype html><html><body>Provider fixture</body></html>",
+  }));
+  let worker = context.serviceWorkers()[0]!;
+  await worker.evaluate(() => chrome.storage.local.set({ onboardingState: { completedVersion: 9999 } }));
+  // Fresh-install onboarding opens a workspace asynchronously.
+  await expect.poll(() => context.pages().filter((page) =>
+    page.url().startsWith(`chrome-extension://${extensionId}/multi-panel/`)).length).toBe(1);
+  for (const page of context.pages()) {
+    if (page.url().startsWith(`chrome-extension://${extensionId}/`)) await page.close();
+  }
+
+  const workspaceUrl = (chat: string) => {
+    const state = Buffer.from(JSON.stringify({
+      v: 1,
+      layout: "1x2",
+      panels: ["chatgpt", "deepseek"],
+      urls: { chatgpt: "https://chatgpt.com/", deepseek: `https://chat.deepseek.com/a/chat/s/${chat}` },
+    })).toString("base64url");
+    return `chrome-extension://${extensionId}/multi-panel/index.html?s=${state}`;
+  };
+  const first = await context.newPage();
+  await first.goto(workspaceUrl("KEEP_A"));
+  const second = await context.newPage();
+  await second.goto(workspaceUrl("KEEP_B"));
+  const closed = await context.newPage();
+  await closed.goto(workspaceUrl("CLOSED"));
+
+  const saved = () => worker.evaluate(async () => {
+    const result = await chrome.storage.local.get("devOpenWorkspaces");
+    return result.devOpenWorkspaces as Array<{ id: number; url: string }>;
+  });
+  await expect.poll(async () => (await saved())?.length).toBe(3);
+  await closed.close();
+  await expect.poll(async () => (await saved())?.length).toBe(2);
+  const urls = (await saved()).map((tab) => tab.url).sort();
+  const extensions = await context.newPage();
+  await extensions.goto("chrome://extensions");
+  // --load-extension permits the initial load, but reload requires this toggle.
+  await extensions.locator("#devMode").click();
+
+  // Two reloads catch stale IDs and duplicate restoration after the first one.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const restarted = context.waitForEvent("serviceworker");
+    await extensions.locator(`extensions-item[id="${extensionId}"] #dev-reload-button`).click();
+    worker = await restarted;
+    await expect.poll(async () => (await saved())?.map((tab) => tab.url).sort()).toEqual(urls);
+    await expect.poll(() => context.pages()
+      .filter((page) => page.url().startsWith(`chrome-extension://${extensionId}/multi-panel/`))
+      .map((page) => page.url()).sort()).toEqual(urls);
+  }
+
+  expect(first.isClosed()).toBe(true);
+  expect(second.isClosed()).toBe(true);
+  const conversations = await Promise.all(context.pages()
+    .filter((page) => page.url().startsWith(`chrome-extension://${extensionId}/multi-panel/`))
+    .map(async (page) => {
+      const frame = page.locator('iframe[src*="chat.deepseek.com"]');
+      await expect(frame).toHaveCount(1);
+      return frame.getAttribute("src");
+    }));
+  expect(conversations.sort()).toEqual([
+    "https://chat.deepseek.com/a/chat/s/KEEP_A",
+    "https://chat.deepseek.com/a/chat/s/KEEP_B",
+  ]);
+});

--- a/tests/e2e/fixtures/dev-reload.spec.ts
+++ b/tests/e2e/fixtures/dev-reload.spec.ts
@@ -44,7 +44,10 @@ test("unpacked reload restores open workspaces but not an intentionally closed t
   const extensions = await context.newPage();
   await extensions.goto("chrome://extensions");
   // --load-extension permits the initial load, but reload requires this toggle.
-  await extensions.locator("#devMode").click();
+  const devMode = extensions.locator("#devMode");
+  const isDevModeEnabled = await devMode.evaluate((toggle) =>
+    Boolean((toggle as HTMLElement & { checked?: boolean }).checked));
+  if (!isDevModeEnabled) await devMode.click();
 
   // Two reloads catch stale IDs and duplicate restoration after the first one.
   for (let attempt = 0; attempt < 2; attempt++) {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -196,6 +196,13 @@ describe("background service worker", () => {
     expect(chrome.tabs.create).not.toHaveBeenCalled();
   });
 
+  it("loads when a test shim exposes management without getSelf", async () => {
+    chrome.management = {} as typeof chrome.management;
+    listeners = loadServiceWorker();
+    await listeners.onInstalled[0]!({ reason: "update" });
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
   it("tracks changed workspace URLs and forgets tabs closed during development", async () => {
     vi.mocked(chrome.management.getSelf).mockResolvedValue({ installType: "development" } as chrome.management.ExtensionInfo);
     listeners = loadServiceWorker();
@@ -237,6 +244,35 @@ describe("background service worker", () => {
     expect(readStorage("local").devOpenWorkspaces).toEqual([{ id: 7, url }, { id: 10, url }]);
     await listeners.onInstalled[0]!({ reason: "update" });
     expect(chrome.tabs.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists successful replacements when a later workspace fails to restore", async () => {
+    vi.mocked(chrome.management.getSelf).mockResolvedValue({ installType: "development" } as chrome.management.ExtensionInfo);
+    listeners = loadServiceWorker();
+    const firstUrl = "chrome-extension://test/multi-panel/index.html?s=first";
+    const secondUrl = "chrome-extension://test/multi-panel/index.html?s=second";
+    seedStorage("local", {
+      devOpenWorkspaces: [{ id: 7, url: firstUrl }, { id: 8, url: secondUrl }],
+    });
+    vi.mocked(chrome.tabs.query).mockResolvedValue([]);
+    vi.mocked(chrome.tabs.create)
+      .mockResolvedValueOnce({ id: 10 })
+      .mockRejectedValueOnce(new Error("tab creation failed"));
+
+    await listeners.onInstalled[0]!({ reason: "update" });
+    expect(readStorage("local").devOpenWorkspaces).toEqual([
+      { id: 10, url: firstUrl },
+      { id: 8, url: secondUrl },
+    ]);
+
+    vi.mocked(chrome.tabs.query).mockResolvedValue([{ id: 10 }] as chrome.tabs.Tab[]);
+    vi.mocked(chrome.tabs.create).mockResolvedValueOnce({ id: 11 });
+    await listeners.onInstalled[0]!({ reason: "update" });
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(3);
+    expect(readStorage("local").devOpenWorkspaces).toEqual([
+      { id: 10, url: firstUrl },
+      { id: 11, url: secondUrl },
+    ]);
   });
 
   it("does not restore development tabs on a worker wakeup or browser startup", async () => {

--- a/tests/unit/service-worker.test.ts
+++ b/tests/unit/service-worker.test.ts
@@ -113,6 +113,9 @@ describe("background service worker", () => {
   let sessionRules: chrome.declarativeNetRequest.Rule[];
 
   beforeEach(() => {
+    chrome.management = {
+      getSelf: vi.fn(async () => ({ installType: "normal" })),
+    } as unknown as typeof chrome.management;
     sessionRules = [];
     chrome.declarativeNetRequest.getSessionRules = vi.fn(async () => [
       ...sessionRules,
@@ -186,8 +189,67 @@ describe("background service worker", () => {
   });
 
   it("onInstalled does not open a tab on update", async () => {
+    seedStorage("local", {
+      devOpenWorkspaces: [{ id: 7, url: "chrome-extension://test/multi-panel/index.html?s=saved" }],
+    });
     await listeners.onInstalled[0]!({ reason: "update" });
     expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
+  it("tracks changed workspace URLs and forgets tabs closed during development", async () => {
+    vi.mocked(chrome.management.getSelf).mockResolvedValue({ installType: "development" } as chrome.management.ExtensionInfo);
+    listeners = loadServiceWorker();
+    const tab = { id: 7, url: "chrome-extension://test/multi-panel/index.html?s=latest" } as chrome.tabs.Tab;
+    emitRuntimeMessage({ type: "DEV_WORKSPACE_URL", url: tab.url }, WORKSPACE_SENDER);
+    await flushAsync();
+    expect(readStorage("local").devOpenWorkspaces).toEqual([tab]);
+
+    vi.mocked(chrome.tabs.query).mockResolvedValue([]);
+    listeners.tabRemoved[0]!(7);
+    await flushAsync();
+    expect(readStorage("local").devOpenWorkspaces).toEqual([]);
+    await listeners.onInstalled[0]!({ reason: "update" });
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+  });
+
+  it("restores missing development tabs once, preserving separate tabs with the same URL", async () => {
+    vi.mocked(chrome.management.getSelf).mockResolvedValue({ installType: "development" } as chrome.management.ExtensionInfo);
+    listeners = loadServiceWorker();
+    const url = "chrome-extension://test/multi-panel/index.html?s=saved";
+    seedStorage("local", {
+      devOpenWorkspaces: [{ id: 7, url }, { id: 8, url }, { id: 9, url: "https://example.com/" }],
+    });
+    const open = [{ id: 7, url }] as chrome.tabs.Tab[];
+    vi.mocked(chrome.tabs.query).mockImplementation(async () => [...open]);
+    vi.mocked(chrome.tabs.create).mockImplementation(async (options) => {
+      const tab = { id: 10, ...options } as chrome.tabs.Tab;
+      open.push(tab);
+      // Real Chrome emits tab events before the install handler finishes.
+      emitRuntimeMessage({ type: "DEV_WORKSPACE_URL", url: tab.url }, {
+        ...WORKSPACE_SENDER, tab,
+      });
+      return tab;
+    });
+
+    await listeners.onInstalled[0]!({ reason: "update" });
+    await flushAsync();
+    expect(chrome.tabs.create).toHaveBeenCalledExactlyOnceWith({ url, active: false });
+    expect(readStorage("local").devOpenWorkspaces).toEqual([{ id: 7, url }, { id: 10, url }]);
+    await listeners.onInstalled[0]!({ reason: "update" });
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not restore development tabs on a worker wakeup or browser startup", async () => {
+    vi.mocked(chrome.management.getSelf).mockResolvedValue({ installType: "development" } as chrome.management.ExtensionInfo);
+    seedStorage("local", {
+      devOpenWorkspaces: [{ id: 7, url: "chrome-extension://test/multi-panel/index.html?s=saved" }],
+    });
+    listeners = loadServiceWorker();
+    await flushAsync();
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+    await listeners.onStartup[0]!();
+    expect(chrome.tabs.create).not.toHaveBeenCalled();
+    expect(readStorage("local").devOpenWorkspaces).toEqual([]);
   });
 
   it("seeds the pre-MiMo provider default on update when storage is missing", async () => {


### PR DESCRIPTION
Chrome closes open extension pages when an unpacked extension reloads, interrupting local development. This change tracks workspace URLs only for development installs, recreates missing tabs after reload, and forgets tabs closed intentionally. Web Store installs skip this path, and no new permissions are added.

Validation:
- `bun run test` (835 tests)
- `bun run test:e2e tests/e2e/fixtures/dev-reload.spec.ts`
- `bun run build`