### PR TITLE
fix(claude): align header title and menu

### DIFF
--- a/content-scripts/claude-iframe-styles.js
+++ b/content-scripts/claude-iframe-styles.js
@@ -1,8 +1,7 @@
 // Parallel AI — Claude iframe style tweaks.
 //
-// Runs only when Claude is embedded inside our extension iframe. Nudges
-// Claude's header so the sidebar toggle and the chat-title dropdown don't
-// crowd each other at the widths used by the Focus view.
+// Runs only when Claude is embedded inside our extension iframe. Reserves
+// header space for our floating menu button so it cannot overlap the title.
 
 (function () {
   'use strict';
@@ -13,11 +12,23 @@
 
   const STYLE_MARKER = 'data-parallel-ai-claude-iframe-styles';
   const STYLE_CONTENT = `
-    /* Inset Claude's header content so the title doesn't run flush against
-       the iframe edges (which causes it to crowd our Focus capsule). */
-    header[data-testid="page-header"] > div[class*="justify-between"] {
-      margin-left: 24px !important;
-      margin-right: 12px !important;
+    /* Reserve space for our menu button. */
+    html:has(> [data-parallel-ai-claude-helper]) [data-testid="chat-header"] {
+      box-sizing: border-box !important;
+      align-items: center !important;
+      padding-left: calc(40px + var(--df-header-start-inset, 1rem) + var(--df-ceded-gutter, 0px)) !important;
+    }
+
+    /* Center the title wrapper even below Claude's md breakpoint. */
+    html:has(> [data-parallel-ai-claude-helper]) [data-testid="chat-header"] > :has([data-testid="chat-title-split"]) {
+      align-self: center !important;
+      align-items: center !important;
+    }
+
+    /* Older Claude layouts use a semantic header without the title outsets. */
+    html:has(> [data-parallel-ai-claude-helper]) header[data-testid="page-header"] {
+      box-sizing: border-box !important;
+      padding-left: 54px !important;
     }
   `;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "130",

--- a/src/content/claude-helper-button.ts
+++ b/src/content/claude-helper-button.ts
@@ -31,8 +31,9 @@
 
     const host = document.createElement("div");
     host.setAttribute(SENTINEL, "true");
+    // Match Claude's native 32px sidebar button in its 48px chat header.
     host.style.cssText =
-      "position:fixed;top:10px;left:10px;z-index:2147483647;";
+      "position:fixed;top:8px;left:8px;display:flex;z-index:2147483647;";
 
     const shadow = host.attachShadow({ mode: "open" });
     shadow.innerHTML = `


### PR DESCRIPTION
The embedded Claude header still uses spacing for its removed native sidebar, causing our menu button to overlap the session title.

This update reserves the native sidebar slot for our menu button, centers the title wrapper across panel widths, matches the menu button to Claude's 8px header inset, and bumps the extension to 1.0.8.

Validation:
- `bun run test -- tests/content-scripts/claude-helper-button.test.ts`
- Production build and shippable-package check
